### PR TITLE
Globaltest

### DIFF
--- a/src/lib/components/NostrElements.svelte
+++ b/src/lib/components/NostrElements.svelte
@@ -17,7 +17,7 @@
   let amount = 50; //1ページに表示する量
   let viewIndex = 0;
   const tieKey = "timeline";
-
+  setTieKey(tieKey);
   onMount(() => {
     setTieKey(tieKey);
   });

--- a/src/lib/components/NostrMainData/SetGlobalRelays.svelte
+++ b/src/lib/components/NostrMainData/SetGlobalRelays.svelte
@@ -6,7 +6,6 @@
   import { useGlobalRelaySet } from "$lib/stores/useGlobalRelaySet";
 
   export let req: RxReqBase | undefined = undefined;
-  let relays: DefaultRelayConfig[] | undefined = undefined;
 
   export let pubkey: string;
 
@@ -28,7 +27,7 @@
 
   interface $$Slots {
     default: {
-      relays: DefaultRelayConfig[];
+      relays: string[];
       status: ReqStatus;
     };
     loading: Record<never, never>;
@@ -37,9 +36,7 @@
   }
 </script>
 
-{#if relays}
-  <slot {relays} status="success" />
-{:else if $error}
+{#if $error}
   <slot name="error" error={$error} />
 {:else if $data && $data.length > 0}
   <slot relays={$data} status={$status ?? "error"} />

--- a/src/lib/components/NostrMainData/TimelineList.svelte
+++ b/src/lib/components/NostrMainData/TimelineList.svelte
@@ -101,6 +101,7 @@
     if (ev) {
       console.log(ev);
       olderEvents = ev;
+      updateViewEvent($data);
       //olderEventsから、今の時間までのあいだのイベントをとるやつ
       const newFilters = filters.map((filter: Nostr.Filter) => ({
         ...filter,
@@ -142,6 +143,7 @@
     ]);
     if (ev) {
       olderEvents = ev;
+      updateViewEvent($data);
       //olderEventsから、今の時間までのあいだのイベントをとるやつ
       const newFilters = filters.map((filter: Nostr.Filter) => ({
         ...filter,

--- a/src/lib/components/NostrMainData/TimelineList.svelte
+++ b/src/lib/components/NostrMainData/TimelineList.svelte
@@ -15,6 +15,9 @@
   import { firstLoadOlderEvents, loadOlderEvents } from "./timelineList";
   import {
     createTie,
+    now,
+    type AcceptableDefaultRelaysConfig,
+    type DefaultRelayConfig,
     type EventPacket,
     type RxReq,
     type RxReqOverable,
@@ -24,7 +27,7 @@
   import Metadata from "./Metadata.svelte";
   import { browser } from "$app/environment";
   import { setTieKey } from "$lib/func/nostr";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
 
   const sift = 40; //スライドする量
 
@@ -96,20 +99,33 @@
     ]);
 
     if (ev) {
+      console.log(ev);
       olderEvents = ev;
       //olderEventsから、今の時間までのあいだのイベントをとるやつ
       const newFilters = filters.map((filter: Nostr.Filter) => ({
         ...filter,
         since: olderEvents[0].event.created_at,
+        until: now(),
       }));
-      const older = await firstLoadOlderEvents(50, newFilters, queryKey);
-
+      const older = await firstLoadOlderEvents(0, newFilters, queryKey, relays);
+      olderEvents.push(...older);
       updateViewEvent($data);
     }
 
     if (olderEvents?.length <= 0) {
       $nowProgress = true;
-      const older = await firstLoadOlderEvents(50, filters, queryKey);
+      const newFilters = filters.map((filter: Nostr.Filter) => ({
+        ...filter,
+        since: undefined,
+        until: now(),
+        limit: 50,
+      }));
+      const older = await firstLoadOlderEvents(
+        50,
+        newFilters,
+        queryKey,
+        relays
+      );
 
       olderEvents.push(...older);
       $queryClient.setQueryData([...queryKey, "olderData"], olderEvents);
@@ -130,12 +146,25 @@
       const newFilters = filters.map((filter: Nostr.Filter) => ({
         ...filter,
         since: olderEvents[0].event.created_at,
+        until: now(),
       }));
-      const older = await firstLoadOlderEvents(50, newFilters, queryKey);
+      const older = await firstLoadOlderEvents(0, newFilters, queryKey, relays);
+      olderEvents.push(...older);
       updateViewEvent($data);
     }
     if (olderEvents?.length <= 0) {
-      const older = await firstLoadOlderEvents(50, filters, queryKey);
+      const newFilters = filters.map((filter: Nostr.Filter) => ({
+        ...filter,
+        since: undefined,
+        until: now(),
+        limit: 50,
+      }));
+      const older = await firstLoadOlderEvents(
+        50,
+        newFilters,
+        queryKey,
+        relays
+      );
 
       olderEvents.push(...older);
       $queryClient.setQueryData([...queryKey, "olderData"], olderEvents);
@@ -164,7 +193,8 @@
         allUniqueEvents,
         filters,
         queryKey,
-        lastfavcheck
+        lastfavcheck,
+        relays
       );
 
       olderEvents.push(...older);
@@ -232,6 +262,10 @@
   function handleClickTop() {
     viewIndex = 0;
   }
+
+  onDestroy(() => {
+    console.log("test");
+  });
 </script>
 
 {#if viewIndex !== 0}

--- a/src/lib/components/NostrMainData/TimelineList.svelte
+++ b/src/lib/components/NostrMainData/TimelineList.svelte
@@ -108,7 +108,13 @@
         since: olderEvents[0].event.created_at,
         until: now(),
       }));
-      const older = await firstLoadOlderEvents(0, newFilters, queryKey, relays);
+      const older = await firstLoadOlderEvents(
+        0,
+        newFilters,
+        queryKey,
+        $tieMapStore[tieKey][0],
+        relays
+      );
       olderEvents.push(...older);
       updateViewEvent($data);
     }
@@ -125,6 +131,7 @@
         50,
         newFilters,
         queryKey,
+        $tieMapStore[tieKey][0],
         relays
       );
 
@@ -150,7 +157,13 @@
         since: olderEvents[0].event.created_at,
         until: now(),
       }));
-      const older = await firstLoadOlderEvents(0, newFilters, queryKey, relays);
+      const older = await firstLoadOlderEvents(
+        0,
+        newFilters,
+        queryKey,
+        $tieMapStore[tieKey][0],
+        relays
+      );
       olderEvents.push(...older);
       updateViewEvent($data);
     }
@@ -165,6 +178,7 @@
         50,
         newFilters,
         queryKey,
+        $tieMapStore[tieKey][0],
         relays
       );
 
@@ -196,6 +210,7 @@
         filters,
         queryKey,
         lastfavcheck,
+        $tieMapStore[tieKey][0],
         relays
       );
 

--- a/src/lib/components/NostrMainData/timelineList.ts
+++ b/src/lib/components/NostrMainData/timelineList.ts
@@ -21,7 +21,8 @@ export async function loadOlderEvents(
   data: EventPacket[], //Nostr.Event[],
   filters: Filter[],
   queryKey: QueryKey,
-  lastfavcheck: boolean
+  lastfavcheck: boolean,
+  relays: string[] | undefined
 ): Promise<EventPacket[]> {
   if (data && data.length > 1) {
     const kind1 = data.filter(
@@ -65,12 +66,15 @@ export async function loadOlderEvents(
     console.log(newFilters);
     const newReq = createRxBackwardReq();
     const operator = pipe(uniq(), verify(), scanArray());
-    const olderEvents = await usePromiseReq({
-      operator: operator,
-      queryKey: queryKey,
-      filters: newFilters,
-      req: newReq,
-    });
+    const olderEvents = await usePromiseReq(
+      {
+        operator: operator,
+        queryKey: queryKey,
+        filters: newFilters,
+        req: newReq,
+      },
+      relays
+    );
     //新しいのからsift分だけもらう（飛び飛びのイベントとかで古いのが取得されてそれ採用するとあいだのイベントが抜けるから）
     return olderEvents
       .sort((a, b) => b.event.created_at - a.event.created_at)
@@ -82,28 +86,22 @@ export async function loadOlderEvents(
 export async function firstLoadOlderEvents(
   sift: number,
   filters: Filter[],
-  queryKey: QueryKey
+  queryKey: QueryKey,
+  relays: string[] | undefined
 ): Promise<EventPacket[]> {
-  const untilTimestamp = now();
-  //最後がkind1だったらほかのkind6とかは間に入ってるってことだからkind6とかも合わせて取得
-  const newFilters = filters.map((filter: Filter) => ({
-    ...filter,
-    limit: sift,
-    until: untilTimestamp,
-    since: undefined,
-  }));
-
-  console.log(newFilters);
   const newReq = createRxBackwardReq();
   const operator = pipe(uniq(), verify(), scanArray());
-  const olderEvents = await usePromiseReq({
-    operator: operator,
-    queryKey: queryKey,
-    filters: newFilters,
-    req: newReq,
-  });
+  const olderEvents = await usePromiseReq(
+    {
+      operator: operator,
+      queryKey: queryKey,
+      filters: filters,
+      req: newReq,
+    },
+    relays
+  );
   //新しいのからsift分だけもらう（飛び飛びのイベントとかで古いのが取得されてそれ採用するとあいだのイベントが抜けるから）
   return olderEvents
     .sort((a, b) => b.event.created_at - a.event.created_at)
-    .slice(0, sift);
+    .slice(0, sift === 0 ? undefined : sift);
 }

--- a/src/lib/components/NostrMainData/timelineList.ts
+++ b/src/lib/components/NostrMainData/timelineList.ts
@@ -11,7 +11,7 @@ import {
   verify,
   type EventPacket,
 } from "rx-nostr";
-import { pipe } from "rxjs";
+import { pipe, type OperatorFunction } from "rxjs";
 import * as Nostr from "nostr-typedef";
 import { get } from "svelte/store";
 import { loginUser } from "$lib/stores/stores";
@@ -22,6 +22,13 @@ export async function loadOlderEvents(
   filters: Filter[],
   queryKey: QueryKey,
   lastfavcheck: boolean,
+  tie: OperatorFunction<
+    EventPacket,
+    EventPacket & {
+      seenOn: Set<string>;
+      isNew: boolean;
+    }
+  >,
   relays: string[] | undefined
 ): Promise<EventPacket[]> {
   if (data && data.length > 1) {
@@ -65,7 +72,7 @@ export async function loadOlderEvents(
         }));
     console.log(newFilters);
     const newReq = createRxBackwardReq();
-    const operator = pipe(uniq(), verify(), scanArray());
+    const operator = pipe(tie, uniq(), verify(), scanArray());
     const olderEvents = await usePromiseReq(
       {
         operator: operator,
@@ -87,10 +94,17 @@ export async function firstLoadOlderEvents(
   sift: number,
   filters: Filter[],
   queryKey: QueryKey,
+  tie: OperatorFunction<
+    EventPacket,
+    EventPacket & {
+      seenOn: Set<string>;
+      isNew: boolean;
+    }
+  >,
   relays: string[] | undefined
 ): Promise<EventPacket[]> {
   const newReq = createRxBackwardReq();
-  const operator = pipe(uniq(), verify(), scanArray());
+  const operator = pipe(tie, uniq(), verify(), scanArray());
   const olderEvents = await usePromiseReq(
     {
       operator: operator,

--- a/src/lib/func/nostr.ts
+++ b/src/lib/func/nostr.ts
@@ -373,7 +373,9 @@ export function setTieKey(key: string) {
   tieKey = key;
 }
 export function getRelaysById(id: string): string[] {
+  //console.log(tieMapStore);
   const tieMap: Map<string, Set<string>> = get(tieMapStore)?.[tieKey]?.[1];
+  //console.log(tieMap);
   return Array.from(tieMap?.get(id) || []);
 }
 export function usePromiseReq(

--- a/src/lib/func/nostr.ts
+++ b/src/lib/func/nostr.ts
@@ -376,13 +376,16 @@ export function getRelaysById(id: string): string[] {
   const tieMap: Map<string, Set<string>> = get(tieMapStore)?.[tieKey]?.[1];
   return Array.from(tieMap?.get(id) || []);
 }
-export function usePromiseReq({
-  queryKey,
-  filters,
-  operator,
-  req,
-  initData = [],
-}: UseReqOpts<EventPacket[] | EventPacket>): Promise<EventPacket[]> {
+export function usePromiseReq(
+  {
+    queryKey,
+    filters,
+    operator,
+    req,
+    initData = [],
+  }: UseReqOpts<EventPacket[] | EventPacket>,
+  relays: string[] | undefined
+): Promise<EventPacket[]> {
   const _rxNostr = get(app).rxNostr;
   if (Object.entries(_rxNostr.getDefaultRelays()).length <= 0) {
     console.log("error");
@@ -412,7 +415,7 @@ export function usePromiseReq({
     : [initData];
 
   const obs: Observable<EventPacket[] | EventPacket> = _rxNostr
-    .use(_req)
+    .use(_req, { relays: relays })
     .pipe(muteCheck(), metadata(), operator, completeOnTimeout(3000));
 
   return new Promise<EventPacket[]>((resolve, reject) => {

--- a/src/lib/stores/useGlobalRelaySet.ts
+++ b/src/lib/stores/useGlobalRelaySet.ts
@@ -21,11 +21,11 @@ export function useGlobalRelaySet(
   queryKey: QueryKey,
   filters: Filter[],
   req?: RxReqBase | undefined
-): ReqResult<DefaultRelayConfig[]> | undefined {
+): any {
   if (Object.entries(get(app).rxNostr.getDefaultRelays()).length <= 0) {
     setRelays(relaySearchRelays);
   }
-  const operator = pipe(verify(), uniq(), scanArray());
+  const operator = pipe(verify(), uniq(), latest());
   const reqResult = useReq({ queryKey, filters, operator, req });
 
   const transformedData = derived(reqResult.data, ($data) =>
@@ -38,7 +38,7 @@ export function useGlobalRelaySet(
     error: reqResult.error,
   };
 }
-
+let stringListRelays: string[];
 function toGlobalRelaySet(
   value: EventPacket | EventPacket[] | undefined
 ): DefaultRelayConfig[] {
@@ -47,46 +47,52 @@ function toGlobalRelaySet(
   if (!value) {
     return [];
   } else if (Array.isArray(value)) {
-    let writerelays: DefaultRelayConfig[] = Object.values(
-      get(app).rxNostr.getDefaultRelays()
-    );
-    let readrelays: DefaultRelayConfig[] = Object.values(
-      get(app).rxNostr.getDefaultRelays()
-    );
+    return value[0].event.tags
+      .filter((tag: string[]) => tag[0] === "relay")
+      .map((tag: any[]) => tag[1]);
+    // let writerelays: DefaultRelayConfig[] = Object.values(
+    //   get(app).rxNostr.getDefaultRelays()
+    // );
+    // let readrelays: DefaultRelayConfig[] = Object.values(
+    //   get(app).rxNostr.getDefaultRelays()
+    // );
 
-    value.forEach((packet) => {
-      //  if (packet.event.kind === 10002) {
-      //   writerelays = setRelaysByKind10002(packet.event);
-      // } else if (packet.event.kind === 30002) {
-      readrelays = setReadRelaysByKind30002(packet.event);
-      //  }
-    });
+    // value.forEach((packet) => {
+    //   //  if (packet.event.kind === 10002) {
+    //   //   writerelays = setRelaysByKind10002(packet.event);
+    //   // } else if (packet.event.kind === 30002) {
+    //   readrelays = setReadRelaysByKind30002(packet.event);
+    //   //  }
+    // });
 
-    const combinedRelays = combineRelays(writerelays, readrelays);
-    setRelays(combinedRelays);
-    console.log(get(app).rxNostr.getDefaultRelays());
-    return combinedRelays;
+    // const combinedRelays = combineRelays(writerelays, readrelays);
+    // //  setRelays(combinedRelays);
+    // console.log(get(app).rxNostr.getDefaultRelays());
+    // return combinedRelays;
   } else {
-    let writerelays: DefaultRelayConfig[] = Object.values(
-      get(app).rxNostr.getDefaultRelays()
-    );
-    let readrelays: DefaultRelayConfig[] = Object.values(
-      get(app).rxNostr.getDefaultRelays()
-    );
+    return value.event.tags
+      .filter((tag: string[]) => tag[0] === "relay")
+      .map((tag: any[]) => tag[1]);
+    // let writerelays: DefaultRelayConfig[] = Object.values(
+    //   get(app).rxNostr.getDefaultRelays()
+    // );
+    // let readrelays: DefaultRelayConfig[] = Object.values(
+    //   get(app).rxNostr.getDefaultRelays()
+    // );
 
-    //if (value.event.kind === 10002) {
-    //writerelays = setRelaysByKind10002(value.event);
-    // } else if (value.event.kind === 30002) {
-    const kind30002 = setReadRelaysByKind30002(value.event);
-    //  }
-    console.log(kind30002);
-    if (kind30002.length > 0) {
-      readrelays = kind30002;
-    }
-    const combinedRelays = combineRelays(writerelays, readrelays);
-    setRelays(combinedRelays);
-    console.log(combinedRelays);
-    return combinedRelays;
+    // //if (value.event.kind === 10002) {
+    // //writerelays = setRelaysByKind10002(value.event);
+    // // } else if (value.event.kind === 30002) {
+    // const kind30002 = setReadRelaysByKind30002(value.event);
+    // //  }
+    // console.log(kind30002);
+    // if (kind30002.length > 0) {
+    //   readrelays = kind30002;
+    // }
+    // const combinedRelays = combineRelays(writerelays, readrelays);
+    // //setRelays(combinedRelays);
+    // console.log(combinedRelays);
+    // return combinedRelays;
   }
 }
 

--- a/src/routes/channel/[note=note]/+page.svelte
+++ b/src/routes/channel/[note=note]/+page.svelte
@@ -24,7 +24,7 @@
   let amount = 50;
   let viewIndex = 0;
   const tieKey = "note";
-
+  setTieKey(tieKey);
   onMount(() => {
     setTieKey(tieKey);
   });

--- a/src/routes/global/+page.svelte
+++ b/src/routes/global/+page.svelte
@@ -25,6 +25,7 @@
   let amount = 50;
   let viewIndex = 0;
   const tieKey = "global";
+  setTieKey(tieKey);
   onMount(() => {
     setTieKey(tieKey);
   });

--- a/src/routes/global/+page.svelte
+++ b/src/routes/global/+page.svelte
@@ -8,14 +8,13 @@
   import { createRxForwardReq, createTie, now, tie } from "rx-nostr";
   import EventCard from "$lib/components/NostrElements/Note/EventCard.svelte";
   import { tieMapStore } from "$lib/stores/stores";
-  import { afterNavigate } from "$app/navigation";
+  import { afterNavigate, beforeNavigate } from "$app/navigation";
   import { setTieKey } from "$lib/func/nostr";
   import { onMount } from "svelte";
 
   let amount = 50;
   let viewIndex = 0;
   const tieKey = "global";
-
   onMount(() => {
     setTieKey(tieKey);
   });
@@ -55,6 +54,7 @@
             {amount}
             let:len
             {tieKey}
+            {relays}
           >
             <SetRepoReactions />
             <div slot="loading">

--- a/src/routes/global/+page.svelte
+++ b/src/routes/global/+page.svelte
@@ -47,14 +47,13 @@
         <div slot="loading">loading</div>
         <div slot="error">error</div>
         <div slot="nodata">nodata</div>
-
-        <div class="w-full break-words overflow-hidden">
-          <div class=" flex gap-2">
-            <div class=" font-medium text-magnum-400">GlobalRelays</div>
-            <div class="text-sm">
-              {relays.join(", ")}
-            </div>
+        <div class=" flex gap-2">
+          <div class="w-full font-medium text-magnum-400">GlobalRelays</div>
+          <div class="text-sm">
+            {relays.join(", ")}
           </div>
+        </div>
+        <div class="w-full break-words overflow-hidden">
           <TimelineList
             queryKey={["global", "feed"]}
             filters={[

--- a/src/routes/global/+page.svelte
+++ b/src/routes/global/+page.svelte
@@ -5,12 +5,22 @@
   import SetDefaultRelays from "$lib/components/NostrMainData/SetDefaultRelays.svelte";
   import SetRepoReactions from "$lib/components/NostrMainData/SetRepoReactions.svelte";
   import TimelineList from "$lib/components/NostrMainData/TimelineList.svelte";
-  import { createRxForwardReq, createTie, now, tie } from "rx-nostr";
+  import {
+    createRxForwardReq,
+    createTie,
+    filterKind,
+    now,
+    tie,
+  } from "rx-nostr";
   import EventCard from "$lib/components/NostrElements/Note/EventCard.svelte";
   import { tieMapStore } from "$lib/stores/stores";
   import { afterNavigate, beforeNavigate } from "$app/navigation";
   import { setTieKey } from "$lib/func/nostr";
   import { onMount } from "svelte";
+  import Link from "$lib/components/Elements/Link.svelte";
+  import { SquareArrowOutUpRight } from "lucide-svelte";
+  import { nip19 } from "nostr-tools";
+  import { _ } from "svelte-i18n";
 
   let amount = 50;
   let viewIndex = 0;
@@ -39,6 +49,12 @@
         <div slot="nodata">nodata</div>
 
         <div class="w-full break-words overflow-hidden">
+          <div class=" flex gap-2">
+            <div class=" font-medium text-magnum-400">GlobalRelays</div>
+            <div class="text-sm">
+              {relays.join(", ")}
+            </div>
+          </div>
           <TimelineList
             queryKey={["global", "feed"]}
             filters={[
@@ -95,6 +111,17 @@
         </div>
       </SetGlobalRelays>
     </SetDefaultRelays>
+    <div
+      class="mb-16 w-full border border-magnum-500 rounded-lg p-2 hover:opacity-75 active:opacity-50 flex justify-center"
+    >
+      <Link
+        className="font-semibold text-magnum-300 break-all inline-flex"
+        href={`https://nostviewstr.vercel.app/${nip19.npubEncode(pubkey)}/${30002}`}
+        >{$_("settings.nostviewstr.kind30002")}<SquareArrowOutUpRight
+          size={16}
+        /></Link
+      >
+    </div>
   </NostrMain>
 </section>
 

--- a/src/routes/list/[naddr=naddr]/+page.svelte
+++ b/src/routes/list/[naddr=naddr]/+page.svelte
@@ -32,6 +32,7 @@
   let amount = 50;
   let viewIndex = 0;
   const tieKey = "naddr";
+  setTieKey(tieKey);
 
   onMount(() => {
     setTieKey(tieKey);

--- a/src/routes/search/SearchResult.svelte
+++ b/src/routes/search/SearchResult.svelte
@@ -6,7 +6,7 @@
   import TimelineList from "../../lib/components/NostrMainData/TimelineList.svelte";
 
   import NostrMain from "../../lib/components/NostrMainData/NostrMain.svelte";
-  import { queryClient, tieMapStore } from "$lib/stores/stores";
+  import { app, queryClient, tieMapStore } from "$lib/stores/stores";
   import SetSearchRelays from "../../lib/components/NostrMainData/SetSearchRelays.svelte";
   import { toRelaySet } from "$lib/stores/useRelaySet";
 
@@ -14,7 +14,7 @@
   import EventCard from "../../lib/components/NostrElements/Note/EventCard.svelte";
   import { setTieKey } from "$lib/func/nostr";
   import { afterNavigate } from "$app/navigation";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   export let filter: Nostr.Filter;
 
   let amount = 50;
@@ -29,6 +29,13 @@
   afterNavigate(() => {
     setTieKey(tieKey);
   });
+  onDestroy(() => {
+    $queryClient.cancelQueries({
+      queryKey: ["search"],
+    });
+    $queryClient.removeQueries({ queryKey: ["search"] });
+    console.log("cancelQueries");
+  });
 </script>
 
 <section>
@@ -42,7 +49,7 @@
     >
       <div class="w-full break-words overflow-x-hidden max-w-full">
         <TimelineList
-          queryKey={["search", "feed", JSON.stringify(filter)]}
+          queryKey={["search", JSON.stringify(filter)]}
           filters={[filter]}
           req={createRxForwardReq()}
           let:events

--- a/src/routes/search/SearchResult.svelte
+++ b/src/routes/search/SearchResult.svelte
@@ -15,6 +15,7 @@
   import { setTieKey } from "$lib/func/nostr";
   import { afterNavigate } from "$app/navigation";
   import { onDestroy, onMount } from "svelte";
+  import SetDefaultRelays from "$lib/components/NostrMainData/SetDefaultRelays.svelte";
   export let filter: Nostr.Filter;
 
   let amount = 50;
@@ -40,13 +41,17 @@
 
 <section>
   <NostrMain let:pubkey let:localRelays>
-    <SetSearchRelays
+    <!-- <SetSearchRelays
       defaultRelays={localRelays.length > 0
         ? localRelays
         : toRelaySet($queryClient.getQueryData(["defaultRelay", pubkey]))}
       setRelayList={nip50relays}
       let:searchRelays
-    >
+    > -->
+    <SetDefaultRelays {pubkey} {localRelays}>
+      <div slot="loading">loading</div>
+      <div slot="error">error</div>
+      <div slot="nodata">nodata</div>
       <div class="w-full break-words overflow-x-hidden max-w-full">
         <TimelineList
           queryKey={["search", JSON.stringify(filter)]}
@@ -57,6 +62,7 @@
           {amount}
           let:len
           {tieKey}
+          relays={nip50relays}
         >
           <SetRepoReactions />
           <div slot="loading">
@@ -98,6 +104,6 @@
           </div>
         </TimelineList>
       </div>
-    </SetSearchRelays>
+    </SetDefaultRelays>
   </NostrMain>
 </section>


### PR DESCRIPTION
めいんTL用のリレー（kind10002か設定したやつ）をデフォルトリレーに固定して、Globalとか検索用のリレーはrxNostrの.use(_req, { relays: relays })のとこにリレーを設定することで混線しなくなったかも？

あと古いイベントのイベントにtie設定忘れてたとこ追加
