### PR TITLE
Fix parsing of content URLs with （）

### DIFF
--- a/src/lib/func/content.ts
+++ b/src/lib/func/content.ts
@@ -409,7 +409,7 @@ export function parseText(input: string, tags: string[][]): Part[] {
           break;
         case "url":
           const url = match[0];
-          const lastUnpairedParenIndex = url.split("").reduce(
+          let lastUnpairedParenIndex = url.split("").reduce(
             (acc, char, idx) => {
               if (char === "(") acc.openParenCount++;
               if (char === ")") acc.closeParenCount++;
@@ -423,7 +423,24 @@ export function parseText(input: string, tags: string[][]): Part[] {
             },
             { openParenCount: 0, closeParenCount: 0, index: url.length }
           ).index;
-
+          if (lastUnpairedParenIndex === url.length) {
+            //()のぺあなし
+            //（）のペアを探してみる
+            lastUnpairedParenIndex = url.split("").reduce(
+              (acc, char, idx) => {
+                if (char === "（") acc.openParenCount++;
+                if (char === "）") acc.closeParenCount++;
+                if (
+                  acc.closeParenCount > acc.openParenCount &&
+                  acc.index === url.length
+                ) {
+                  acc.index = idx;
+                }
+                return acc;
+              },
+              { openParenCount: 0, closeParenCount: 0, index: url.length }
+            ).index;
+          }
           // Split the URL into its proper parts
           const urlPart = url.slice(0, lastUnpairedParenIndex);
           const textPart = url.slice(lastUnpairedParenIndex);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -219,6 +219,8 @@
         )
       : undefined
   ); //data.relaysにちょっとしかなかったらデフォリレーから足す
+
+  console.log($page.url.origin);
 </script>
 
 <svelte:document on:visibilitychange={onVisibilityChange} />


### PR DESCRIPTION
※URLに（）が入ることはあるけど、
ただURLをかこうための（）がくっついてくるときもあるから、
URLのなかに開きカッコがないのに閉じ括弧が現れたらそれはURLから省くを
半角カッコだけやってたやつを全角でもやる
![](https://share.yabu.me/84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5/1575af6fbe950384f57e0b9a2f4fc9c590815158d7cdc2fb1b93856419333936.webp)