### PR TITLE
feat(notifications): persist filter selection to localStorage and restore on init

### DIFF
--- a/src/lib/components/Elements/IconButton.svelte
+++ b/src/lib/components/Elements/IconButton.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { melt } from "@melt-ui/svelte";
+
+  interface Props {
+    children: Snippet;
+    type?: HTMLButtonElement["type"];
+    disabled?: boolean;
+    onclick?: (event: MouseEvent) => void;
+    useMelt?: any;
+    title: string;
+    className?: string;
+    zIndex?: number;
+    size?: number; // アイコンサイズ(px)
+    variant?: "fill" | "outline" | "ghost";
+  }
+
+  const {
+    children,
+    type = "button",
+    disabled = false,
+    onclick,
+    useMelt,
+    title,
+    className = "",
+    zIndex = 0,
+    size = 20,
+    variant = "fill",
+  }: Props = $props();
+
+  const variantClass: Record<typeof variant, string> = {
+    fill: "bg-magnum-700 text-magnum-100",
+    outline: "bg-transparent border border-neutral-400 text-magnum-800",
+    ghost: "bg-transparent text-magnum-800",
+  };
+
+  const buttonSizeClassName = `h-[${size + 12}px] w-[${size + 12}px]`;
+
+  const commonClasses = [
+    "inline-flex",
+    "items-center",
+    "justify-center",
+    "rounded-full",
+    "duration-100",
+    "scale-95",
+    "hover:scale-100",
+    "active:scale-90",
+  ];
+</script>
+
+{#if useMelt}
+  <button
+    {type}
+    {disabled}
+    {onclick}
+    {title}
+    use:melt={useMelt}
+    style={`z-index:${zIndex};`}
+    class={`${commonClasses.join(" ")} ${buttonSizeClassName} ${variantClass[variant]} ${className}`}
+  >
+    {@render children()}
+  </button>
+{:else}<button
+    {type}
+    {disabled}
+    {onclick}
+    {title}
+    style={`z-index:${zIndex};`}
+    class={`${commonClasses.join(" ")} ${buttonSizeClassName} ${variantClass[variant]} ${className}`}
+  >
+    {@render children()}
+  </button>
+{/if}

--- a/src/lib/components/renderSnippets/nostr/NostrMain.svelte
+++ b/src/lib/components/renderSnippets/nostr/NostrMain.svelte
@@ -4,7 +4,6 @@
     emojis,
     mutebykinds,
     mutes,
-    onlyFollowee,
     queryClient,
   } from "$lib/stores/stores";
   import { setRxNostr, setRelays } from "$lib/func/nostr";
@@ -32,6 +31,7 @@
   import type { QueryKey } from "@tanstack/svelte-query";
 
   import { STORAGE_KEYS } from "$lib/func/localStorageKeys";
+  import { migrateNotifiSettings } from "../../../../routes/notifications/notifiSettingsRepository";
 
   let {
     contents,
@@ -47,8 +47,9 @@
   onMount(() => {
     try {
       initializeRxNostr();
-      const followee = localStorage.getItem(STORAGE_KEYS.OLD_ONLY_FOLLOWEE);
-      if (followee === "true") $onlyFollowee = true;
+      // Load migrated settings
+
+      migrateNotifiSettings();
 
       const raw = localStorage.getItem(STORAGE_KEYS.TIMELINE_FILTER);
       let saved: unknown = null;

--- a/src/lib/func/localStorageKeys.ts
+++ b/src/lib/func/localStorageKeys.ts
@@ -16,7 +16,7 @@ export const STORAGE_KEYS = {
   // 移行前の旧キー
   OLD_ONLY_FOLLOWEE: "onlyFollowee",
   // 移行後の新キー
-  NOTIFI_SETTINGS: "lumi-notifications", //{onluFollowee:boolean,selects:string[]}
+  NOTIFI_SETTINGS: "lumi-notifi", //{onluFollowee:boolean,selects:string[]}
 };
 
 export const getKind3Key = (pubkey: string) => `kind3-${pubkey}`;

--- a/src/lib/stores/globalRunes.svelte.ts
+++ b/src/lib/stores/globalRunes.svelte.ts
@@ -8,7 +8,10 @@ import * as Nostr from "nostr-typedef";
 import type { ConnectionState } from "rx-nostr";
 import type { EventVerifier } from "rx-nostr-crypto";
 import { SvelteMap } from "svelte/reactivity";
+import type { NotifiSettings } from "../../routes/notifications/notifiSettingsRepository";
+import { notifiInit } from "../../routes/notifications/notificationTypes";
 
+export const notifiSettings = createCustomStore<NotifiSettings>(notifiInit);
 export const loginUser = createCustomStore<string>("");
 export const displayEvents = createCustomStore<Nostr.Event[]>([]);
 export const timelineFilter =

--- a/src/lib/stores/operators.ts
+++ b/src/lib/stores/operators.ts
@@ -2,12 +2,7 @@ import type { EventPacket } from "rx-nostr";
 import { latestEach } from "rx-nostr";
 import type { OperatorFunction } from "rxjs";
 import { filter, from, map, mergeMap, of, pipe, scan, tap } from "rxjs";
-import {
-  metadataQueue,
-  onlyFollowee,
-  queryClient,
-  reactionToast,
-} from "./stores";
+import { metadataQueue, queryClient, reactionToast } from "./stores";
 import { get } from "svelte/store";
 import * as Nostr from "nostr-typedef";
 import { sortEventPackets } from "$lib/func/util";
@@ -18,6 +13,7 @@ import {
   bookmark10003,
   followList,
   lumiSetting,
+  notifiSettings,
   timelineFilter,
   userStatusMap,
 } from "$lib/stores/globalRunes.svelte";
@@ -321,7 +317,8 @@ export function reactionCheck(show: boolean) {
         } else {
           // フォロー外からの反応は通知のみ
           const canShow =
-            muteCheckEvent(event) === "null" && !get(onlyFollowee);
+            muteCheckEvent(event) === "null" &&
+            !notifiSettings.get().onlyFollowee;
           maybeSetReaction(canShow);
           return false;
         }
@@ -335,7 +332,7 @@ export function reactionCheck(show: boolean) {
     if (isReactionEvent) {
       // フォロイーからのリアクション、または「フォロイーのみ」設定がオフの場合に通知をセット
       const isFollower = isFollowingUser(event.pubkey);
-      const canShow = isFollower || !get(onlyFollowee);
+      const canShow = isFollower || !notifiSettings.get().onlyFollowee;
       maybeSetReaction(canShow);
     }
 

--- a/src/lib/stores/stores.ts
+++ b/src/lib/stores/stores.ts
@@ -83,7 +83,7 @@ export const viewMediaModal = writable<{
   mediaList: string[];
 }>();
 
-export const onlyFollowee = writable<boolean>(false); //通知欄
+//export const onlyFollowee = writable<boolean>(false); //通知欄
 //export const reactionList = writable<Nostr.Event[]>([]);
 export const reactionToast = writable<{
   title: string;

--- a/src/routes/notifications/+page.svelte
+++ b/src/routes/notifications/+page.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import { now, type EventPacket } from "rx-nostr";
-  import { onlyFollowee, queryClient } from "$lib/stores/stores";
+  import { queryClient } from "$lib/stores/stores";
   import { afterNavigate, beforeNavigate } from "$app/navigation";
   import { onMount } from "svelte";
   import { createToggleGroup, melt } from "@melt-ui/svelte";
   import { t as _ } from "@konemono/svelte5-i18n";
   import type { QueryKey } from "@tanstack/svelte-query";
   import type * as Nostr from "nostr-typedef";
-  import { Heart, Repeat2, Reply, Zap } from "lucide-svelte";
 
   import OpenPostWindow from "$lib/components/OpenPostWindow.svelte";
   import NotificationFilter from "./NotificationFilter.svelte";
@@ -15,43 +14,29 @@
   import EventCard from "$lib/components/NostrElements/kindEvents/EventCard/EventCard.svelte";
   import NotificationList from "./NotificationList.svelte";
   import { extractKind9734 } from "$lib/func/zap";
-  import { followList, lumiSetting } from "$lib/stores/globalRunes.svelte";
+  import {
+    followList,
+    lumiSetting,
+    notifiSettings,
+  } from "$lib/stores/globalRunes.svelte";
+
   import { notificationKinds } from "$lib/func/constants";
+  import { NOTIFICATION_TYPES } from "./notificationTypes";
+  import { saveNotifiSettings } from "./notifiSettingsRepository";
 
   // Constants
   const TIMELINE_QUERY: QueryKey = ["notifications"];
-
   const DISPLAY_AMOUNT = 50;
   const INITIAL_LOAD_LIMIT = 100;
 
-  // Notification types configuration
-  type NotificationType = {
-    id: string;
-    title: any;
-    kinds: number[];
-  };
-
-  // Define base notification types
-  const BASE_NOTIFICATION_TYPES: NotificationType[] = [
-    { id: "reaction", title: Heart, kinds: [7] },
-    { id: "reply", title: Reply, kinds: [1] },
-    { id: "repost", title: Repeat2, kinds: [6, 16] },
-    { id: "zap", title: Zap, kinds: [9735] },
-  ];
-
-  // Get all kinds covered by specific notification types
-  const coveredKinds = BASE_NOTIFICATION_TYPES.flatMap((type) => type.kinds);
-
-  // Generate "other" kinds dynamically
-  const otherKinds = notificationKinds.filter(
-    (kind) => !coveredKinds.includes(kind)
-  );
-
-  // Complete notification types including "other" category
-  const NOTIFICATION_TYPES: NotificationType[] = [
-    ...BASE_NOTIFICATION_TYPES,
-    { id: "other", title: "other", kinds: otherKinds },
-  ];
+  // Initialize toggle group for notification filtering
+  const {
+    elements: { root, item },
+    states: { value },
+  } = createToggleGroup({
+    type: "multiple",
+    defaultValue: notifiSettings.get().selects,
+  });
 
   // State
   let viewIndex = 0;
@@ -73,15 +58,6 @@
         ]
       : null
   );
-
-  // Initialize toggle group for notification filtering
-  const {
-    elements: { root, item },
-    states: { value },
-  } = createToggleGroup({
-    type: "multiple",
-    defaultValue: NOTIFICATION_TYPES.map((type) => type.id),
-  });
 
   // Lifecycle hooks
   onMount(async () => {
@@ -111,35 +87,29 @@
   // Subscribe to filter changes
   value?.subscribe((val) => {
     setTimeout(() => {
-      if (val !== undefined && updateViewNotifi) {
+      if (Array.isArray(val) && updateViewNotifi) {
         updateViewNotifi();
+
+        saveNotifiSettings({
+          onlyFollowee: notifiSettings.get().onlyFollowee,
+          selects: val,
+        });
       }
-    }, 0); // Delay to ensure value is updated
+    }, 0);
   });
 
   // Filter helpers
   function getNotificationFilterPredicate(event: Nostr.Event): boolean {
-    // Skip self-notifications
-    if (event.pubkey === lumiSetting.get()?.pubkey) {
-      return false;
+    if (event.pubkey === lumiSetting.get()?.pubkey) return false;
+
+    if (notifiSettings.get().onlyFollowee && followList.get()) {
+      if (!isEventFromFollowedUser(event)) return false;
     }
 
-    // Apply follow filter if needed
-    if ($onlyFollowee && followList.get()) {
-      if (!isEventFromFollowedUser(event)) {
-        return false;
-      }
-    }
-
-    // Verify p-tag addresses the current user for certain event kinds
     if ([7, 6, 16].includes(event.kind)) {
-      //別のユーザーあての可能性あるからラストが自分か確認
-      if (!isEventAddressedToUser(event)) {
-        return false;
-      }
+      if (!isEventAddressedToUser(event)) return false;
     }
 
-    // Apply selected notification type filters
     return isSelectedNotificationType(event);
   }
 
@@ -150,7 +120,6 @@
     if (event.kind !== 9735) {
       return followListSet.has(event.pubkey);
     } else {
-      // For zap receipts, check the sender from kind 9734
       const kind9734 = extractKind9734(event);
       return (kind9734 && followListSet.has(kind9734.pubkey)) || false;
     }
@@ -160,7 +129,6 @@
     const targetPubkey = event.tags.findLast(
       (tag) => tag[0] === "p" && tag.length > 1
     )?.[1];
-
     return targetPubkey === lumiSetting.get().pubkey;
   }
 
@@ -174,6 +142,7 @@
       return typeConfig.kinds.includes(event.kind);
     });
   }
+
   // Toggle button handlers
   function selectAllNotificationTypes() {
     value.set(NOTIFICATION_TYPES.map((type) => type.id));
@@ -189,12 +158,10 @@
       queryClient?.getQueryData(TIMELINE_QUERY);
     if (!filters) return;
     if (!existingEvents || existingEvents.length <= 0) {
-      // First load - get historical events
       filters[0].since = undefined;
       filters[0].limit = INITIAL_LOAD_LIMIT;
       filters[0].until = now();
     } else {
-      // Subsequent load - get new events since last known
       filters[0].since = existingEvents[0].event.created_at;
       filters[0].until = now();
     }
@@ -308,16 +275,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
-
     user-select: none;
-
     border-radius: 0;
     background-color: theme("colors.neutral.800");
-
     color: theme("colors.magnum.200");
     font-weight: 500;
     line-height: 1;
-
     flex: 1;
     height: theme(spacing.12);
     padding-inline: theme(spacing.2);
@@ -363,6 +326,7 @@
   .toggle-item[data-state="on"] {
     @apply bg-magnum-200 text-magnum-900;
   }
+
   .toggle-item:disabled {
     @apply bg-magnum-200 text-magnum-900;
   }

--- a/src/routes/notifications/NotificationFilter.svelte
+++ b/src/routes/notifications/NotificationFilter.svelte
@@ -1,21 +1,20 @@
 <script lang="ts">
-  import { STORAGE_KEYS } from "$lib/func/localStorageKeys";
-  import { followList } from "$lib/stores/globalRunes.svelte";
-
-  import { onlyFollowee } from "$lib/stores/stores";
+  import { followList, notifiSettings } from "$lib/stores/globalRunes.svelte";
 
   import { t as _ } from "@konemono/svelte5-i18n";
+  import { saveNotifiSettings } from "./notifiSettingsRepository";
+
+  let onlyFollowee = $derived(notifiSettings.get().onlyFollowee);
 
   const handleChangeChecked = () => {
-    console.log($onlyFollowee);
-    try {
-      localStorage.setItem(
-        STORAGE_KEYS.OLD_ONLY_FOLLOWEE,
-        $onlyFollowee.toString()
-      );
-    } catch (error) {
-      console.log("Failed to save");
-    }
+    notifiSettings.update((current) => {
+      const updated = {
+        ...current,
+        onlyFollowee: !notifiSettings.get().onlyFollowee,
+      };
+      saveNotifiSettings(updated);
+      return updated;
+    });
   };
 </script>
 
@@ -24,7 +23,7 @@
     <input
       type="checkbox"
       class="rounded-checkbox"
-      bind:checked={$onlyFollowee}
+      bind:checked={onlyFollowee}
       onchange={handleChangeChecked}
     />
     {$_("notifications.onlyFollowee")}

--- a/src/routes/notifications/NotificationList.svelte
+++ b/src/routes/notifications/NotificationList.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
   import { afterNavigate } from "$app/navigation";
   import { page } from "$app/state";
-  import {
-    nowProgress,
-    onlyFollowee,
-    queryClient,
-    tie,
-  } from "$lib/stores/stores";
+  import { nowProgress, queryClient, tie } from "$lib/stores/stores";
   import {
     type QueryKey,
     createQuery,
@@ -29,7 +24,11 @@
   } from "$lib/components/renderSnippets/nostr/timelineList";
   import Metadata from "$lib/components/renderSnippets/nostr/Metadata.svelte";
   import { usePromiseReq } from "$lib/func/nostr";
-  import { displayEvents, lumiSetting } from "$lib/stores/globalRunes.svelte";
+  import {
+    displayEvents,
+    lumiSetting,
+    notifiSettings,
+  } from "$lib/stores/globalRunes.svelte";
 
   // Constants
   const SLIDE_AMOUNT = 40; // Amount to slide when navigating
@@ -159,7 +158,7 @@
   });
 
   // Update view when follow filter changes
-  onlyFollowee.subscribe(() => {
+  notifiSettings.subscribe(() => {
     updateViewNotifi();
   });
 

--- a/src/routes/notifications/notifiSettingsRepository.ts
+++ b/src/routes/notifications/notifiSettingsRepository.ts
@@ -1,0 +1,53 @@
+import { STORAGE_KEYS } from "$lib/func/localStorageKeys";
+import { notifiSettings } from "$lib/stores/globalRunes.svelte";
+import { NOTIFICATION_TYPES } from "./notificationTypes";
+
+export type NotifiSettings = {
+  onlyFollowee: boolean;
+  selects: string[];
+};
+
+// load or migrate (but not auto-save updates)
+export function migrateNotifiSettings() {
+  const raw = localStorage.getItem(STORAGE_KEYS.NOTIFI_SETTINGS);
+
+  if (raw) {
+    try {
+      const notifi = JSON.parse(raw) as NotifiSettings;
+      notifiSettings.set(notifi);
+    } catch {
+      // 壊れていたら初期化
+      const settings: NotifiSettings = {
+        onlyFollowee: false,
+        selects: NOTIFICATION_TYPES.map((t) => t.id),
+      };
+      localStorage.setItem(
+        STORAGE_KEYS.NOTIFI_SETTINGS,
+        JSON.stringify(settings)
+      );
+      notifiSettings.set(settings);
+    }
+  } else {
+    // データが無い場合 → 初期化 & 移行
+    const followee = localStorage.getItem(STORAGE_KEYS.OLD_ONLY_FOLLOWEE);
+    const settings: NotifiSettings = {
+      onlyFollowee: followee === "true",
+      selects: NOTIFICATION_TYPES.map((t) => t.id),
+    };
+    localStorage.setItem(
+      STORAGE_KEYS.NOTIFI_SETTINGS,
+      JSON.stringify(settings)
+    );
+    notifiSettings.set(settings);
+  }
+
+  // 既存データがあっても OLD キーが残っていれば削除のみ
+  if (localStorage.getItem(STORAGE_KEYS.OLD_ONLY_FOLLOWEE) !== null) {
+    localStorage.removeItem(STORAGE_KEYS.OLD_ONLY_FOLLOWEE);
+  }
+}
+
+// 保存関数を追加
+export function saveNotifiSettings(settings: NotifiSettings) {
+  localStorage.setItem(STORAGE_KEYS.NOTIFI_SETTINGS, JSON.stringify(settings));
+}

--- a/src/routes/notifications/notificationTypes.ts
+++ b/src/routes/notifications/notificationTypes.ts
@@ -1,0 +1,34 @@
+import { Heart, Repeat2, Reply, Zap } from "lucide-svelte";
+import { notificationKinds } from "$lib/func/constants";
+
+export type NotificationType = {
+  id: string;
+  title: any;
+  kinds: number[];
+};
+
+// Base notification types
+const BASE_NOTIFICATION_TYPES: NotificationType[] = [
+  { id: "reaction", title: Heart, kinds: [7] },
+  { id: "reply", title: Reply, kinds: [1] },
+  { id: "repost", title: Repeat2, kinds: [6, 16] },
+  { id: "zap", title: Zap, kinds: [9735] },
+];
+
+// Covered kinds
+const coveredKinds = BASE_NOTIFICATION_TYPES.flatMap((t) => t.kinds);
+
+// Other kinds
+const otherKinds = notificationKinds.filter((k) => !coveredKinds.includes(k));
+
+// Complete set
+export const NOTIFICATION_TYPES: NotificationType[] = [
+  ...BASE_NOTIFICATION_TYPES,
+  { id: "other", title: "other", kinds: otherKinds },
+];
+
+// 初期値オブジェクト
+export const notifiInit = {
+  onlyFollowee: false,
+  selects: NOTIFICATION_TYPES.map((t) => t.id),
+};


### PR DESCRIPTION
従来は onlyFollowee を単独のキーで保持していたが、
今回からフィルター選択状態とあわせて通知設定として
1つのストレージキーにまとめて管理するようにした