### PR TITLE
relayHintがnullになるケースがあるので修正

### DIFF
--- a/src/lib/components/NostrElements/kindEvents/NoteActionButtuns/EllipsisMenu.svelte
+++ b/src/lib/components/NostrElements/kindEvents/NoteActionButtuns/EllipsisMenu.svelte
@@ -534,7 +534,7 @@
             }
           }
 
-          const relayHint = getRelaysById(note.id)[0];
+          const relayHint = getRelayById(note.id);
           const tags = (): string[][] => {
             const [tagType, tagValue] = replaceable
               ? [


### PR DESCRIPTION
恐らくスマートフォン限定だと思われますが、直接イベントページ([例](https://lumilumi.app/nevent1qvzqqqqqqypzpjj4mes9vx4va6wrratujk76cqtttdf5555zxdvvd5vtagkwvcjhqyt8wumn8ghj7mn0wd68ytnp0f6kk6fwvfk82egpr3mhxue69uhhyetvv9ujucm0d43k7mtsdahx2mn59e3k7mgpr9mhxue69uhhyetvv9uj66ns9eeks6twduejumn9wsq3zamnwvaz7tmj9e4k76nfwfsju6t0qy28wumn8ghj7un9d3shjtnyv9kh2uewd9hszxthwden5te0d3skueewwfjkcctewvhxcctwvshk5cgpp4mhxue69uhkummn9ekx7mqqyrncps7eu30cs0zsuzep44nh22t8rp9jw3gwpdq8qampsfz2dgmajena5t7))を開いた上でブックマークを追加すると、クライアント側にリレーの情報が存在しないためリレーヒントを拾えず、結果nullが入ってイベントが壊れるため、getRelaysByIdをgetRelayByIdに置き換える修正をしました。

現状リレーヒントが存在しない場合に空文字列が入りますが、入れない方がよければ修正します。