### PR TITLE
Wip fix required

### DIFF
--- a/src/lib/components/NostrElements/content/ContentImage.svelte
+++ b/src/lib/components/NostrElements/content/ContentImage.svelte
@@ -19,7 +19,7 @@
     lumiSetting.get().imageAutoExpand === "all" ||
       (lumiSetting.get().imageAutoExpand === "following" &&
         author &&
-        (author === lumiSetting.get().pubkey || followList.get().has(author)))
+        (author === lumiSetting.get().pubkey || followList.get().has(author))),
   );
 </script>
 

--- a/src/lib/components/NostrElements/kindEvents/ChannelMetadata.svelte
+++ b/src/lib/components/NostrElements/kindEvents/ChannelMetadata.svelte
@@ -28,24 +28,23 @@
     {@render channelMetadata?.(null)}
   {/snippet}
   {#snippet content({ data: kind40Event })}
-    <LatestEvent
-      queryKey={["channel", "kind41", id]}
-      filters={[
-        { kinds: [41], authors: [kind40Event.pubkey], limit: 1, "#e": [id] },
-      ]}
-    >
-      {#snippet success({ event: kind41Event })}
-        {@render channelMetadata?.(kind41Event)}
-      {/snippet}
-      {#snippet loading()}
-        {@render channelMetadata?.(kind40Event)}
-      {/snippet}
-      {#snippet nodata()}
-        {@render channelMetadata?.(kind40Event)}
-      {/snippet}
-      {#snippet error()}
-        {@render channelMetadata?.(kind40Event)}
-      {/snippet}
-    </LatestEvent>
+    {#if kind40Event?.pubkey}
+      <LatestEvent
+        queryKey={["channel", "kind41", id]}
+        filters={[{ kinds: [41], limit: 1, "#e": [id] }]}
+      >
+        {#snippet success({ event: kind41Event })}
+          {@render channelMetadata?.(kind41Event)}
+        {/snippet}
+        {#snippet loading()}
+          {@render channelMetadata?.(kind40Event)}
+        {/snippet}
+        {#snippet nodata()}
+          {@render channelMetadata?.(kind40Event)}
+        {/snippet}
+        {#snippet error()}
+          {@render channelMetadata?.(kind40Event)}
+        {/snippet}
+      </LatestEvent>{/if}
   {/snippet}
 </Text>

--- a/src/lib/components/NostrElements/kindEvents/NoteActionButtuns/EllipsisMenu.svelte
+++ b/src/lib/components/NostrElements/kindEvents/NoteActionButtuns/EllipsisMenu.svelte
@@ -64,7 +64,6 @@
   } from "$lib/stores/globalRunes.svelte";
   import type { QueryKey } from "@tanstack/svelte-query";
   import { addToast } from "$lib/components/Elements/Toast.svelte";
-  import { useLatestEvent } from "$lib/stores/useLatestEvent";
 
   interface MenuItem {
     text: string;
@@ -102,7 +101,7 @@
   let deleteDialogOpen: (bool: boolean) => void = $state(() => {});
 
   let replaceable = $derived(
-    note && (isReplaceableKind(note.kind) || isAddressableKind(note.kind))
+    note && (isReplaceableKind(note.kind) || isAddressableKind(note.kind)),
   );
 
   let { naddr, nevent, encodedPubkey } = $derived.by(() => {
@@ -378,7 +377,7 @@
       case "copy_id":
         try {
           await navigator.clipboard.writeText(
-            replaceable ? (naddr ?? "") : (nevent ?? "")
+            replaceable ? (naddr ?? "") : (nevent ?? ""),
           );
           addToast({
             data: {
@@ -542,7 +541,7 @@
                   queryClient.setQueryData(key, () => data[0]);
                 }
               }
-            }
+            },
           );
         } catch (error) {
           console.error(error);
@@ -573,7 +572,7 @@
                 operator: pipe(latest()),
               },
               undefined,
-              2000
+              2000,
             );
 
             if (bookmarkEvent.length > 0) {

--- a/src/lib/components/renderSnippets/nostr/ChannelMain.svelte
+++ b/src/lib/components/renderSnippets/nostr/ChannelMain.svelte
@@ -44,8 +44,12 @@
   }: Props = $props();
 
   let result = $derived(
-    useReplaceableEvent($app?.rxNostr, queryKey, pubkey, 10005, req)
+    useReplaceableEvent($app?.rxNostr, queryKey, pubkey, 10005, req),
   );
+  $effect(() => {
+    const currentResult = result;
+    return () => currentResult.destroy();
+  });
   let data = $derived(result.data);
   let status = $derived(result.status);
   let errorData = $derived(result.error);

--- a/src/lib/components/renderSnippets/nostr/Contacts.svelte
+++ b/src/lib/components/renderSnippets/nostr/Contacts.svelte
@@ -27,7 +27,7 @@
     onchange?: (contacts: Nostr.Event) => void;
     onstatechange?: (
       status: ReqStatus,
-      contacts: Nostr.Event | undefined
+      contacts: Nostr.Event | undefined,
     ) => void;
   }
 
@@ -50,9 +50,14 @@
   });
 
   let result = $derived(
-    $app?.rxNostr ? useContacts($app.rxNostr, queryKey, pubkey, req) : undefined
+    $app?.rxNostr
+      ? useContacts($app.rxNostr, queryKey, pubkey, req)
+      : undefined,
   );
-
+  $effect(() => {
+    const currentResult = result;
+    return () => currentResult?.destroy();
+  });
   let data = $derived(result?.data);
   let status = $derived(result?.status);
   let contactsEvent = $derived(data && $data?.event);

--- a/src/lib/components/renderSnippets/nostr/LatestEvent.svelte
+++ b/src/lib/components/renderSnippets/nostr/LatestEvent.svelte
@@ -1,3 +1,4 @@
+<!--LatestEvent.svelte-->
 <script lang="ts">
   import { useLatestEvent } from "$lib/stores/useLatestEvent";
 
@@ -45,6 +46,10 @@
 
   let max3relays = $derived(relays ? relays.slice(0, 3) : undefined);
   let result = $derived(useLatestEvent(queryKey, filters, req, max3relays));
+  $effect(() => {
+    const currentResult = result;
+    return () => currentResult.destroy();
+  });
   let data = $derived(result.data);
   let status = $derived(result.status);
   let errorData = $derived(result.error);

--- a/src/lib/components/renderSnippets/nostr/LatestEvent.svelte
+++ b/src/lib/components/renderSnippets/nostr/LatestEvent.svelte
@@ -54,7 +54,6 @@
   let status = $derived(result.status);
   let errorData = $derived(result.error);
   let event = $derived($data?.event);
-
   $effect(() => {
     if (event) {
       untrack(() => onChange?.(event));

--- a/src/lib/components/renderSnippets/nostr/ListMain.svelte
+++ b/src/lib/components/renderSnippets/nostr/ListMain.svelte
@@ -52,6 +52,10 @@
     }), */
 
   let result = $derived(useReplaceableEventList(queryKey, pubkey, kind, req));
+  $effect(() => {
+    const currentResult = result;
+    return () => currentResult.destroy();
+  });
   let data = $derived(result.data);
   let status = $derived(result.status);
   let errorData = $derived(result.error);

--- a/src/lib/components/renderSnippets/nostr/Metadata.svelte
+++ b/src/lib/components/renderSnippets/nostr/Metadata.svelte
@@ -55,7 +55,7 @@
   let localData = $derived(getMetadata(queryKey));
   //console.log(localData);
   let initData: EventPacket | undefined = $derived(
-    lumiSetting.get().showImg ? undefined : localData
+    lumiSetting.get().showImg ? undefined : localData,
   ); //画像オンのときは初っ端最新チェックなのでinitDataいらないけど代わりにローディングのときとかにおいてみる
 
   let result = $derived(
@@ -67,8 +67,8 @@
       initData,
       staleTime,
       undefined,
-      refetchInterval
-    )
+      refetchInterval,
+    ),
   );
 
   let data = $derived(result.data);

--- a/src/lib/components/renderSnippets/nostr/Reactionsforme.svelte
+++ b/src/lib/components/renderSnippets/nostr/Reactionsforme.svelte
@@ -34,6 +34,10 @@
     $props();
 
   let result = $derived(useUniqueEventList(queryKey, filters, req));
+  $effect(() => {
+    const currentResult = result;
+    return () => currentResult.destroy();
+  });
   let data = $derived(result.data);
   let status = $derived(result.status);
   let errorData = $derived(result.error);

--- a/src/lib/components/renderSnippets/nostr/Text.svelte
+++ b/src/lib/components/renderSnippets/nostr/Text.svelte
@@ -4,11 +4,11 @@
   import type { ReqStatus } from "$lib/types";
 
   import type Nostr from "nostr-typedef";
-  import type {
-    RxReq,
-    RxReqEmittable,
-    RxReqOverable,
-    RxReqPipeable,
+  import {
+    type RxReq,
+    type RxReqEmittable,
+    type RxReqOverable,
+    type RxReqPipeable,
   } from "rx-nostr";
   import { untrack, type Snippet } from "svelte";
 

--- a/src/lib/components/renderSnippets/nostr/Text.svelte
+++ b/src/lib/components/renderSnippets/nostr/Text.svelte
@@ -1,3 +1,4 @@
+<!--Text.svelte-->
 <script lang="ts">
   import { useEvent } from "$lib/stores/useEvent";
   import type { ReqStatus } from "$lib/types";
@@ -45,6 +46,12 @@
   let queryKey = $derived(["note", id]);
   let max3relays = $derived(relays ? relays.slice(0, 3) : undefined);
   let result = $derived(useEvent(queryKey, id, req, max3relays));
+
+  $effect(() => {
+    const currentResult = result; // effectの依存としてresultを追跡
+    return () => currentResult.destroy();
+  });
+
   let data = $derived(result.data);
   let status = $derived(result.status);
   let errorData = $derived(result.error);

--- a/src/lib/components/renderSnippets/nostr/TimelineList.svelte
+++ b/src/lib/components/renderSnippets/nostr/TimelineList.svelte
@@ -114,8 +114,6 @@
     }
   }
 
-  const configureOperators = pipe(tie, uniq(), scanArray());
-
   let olderQueryKey = $derived([...queryKey, "olderData"]);
 
   onDestroy(() => {
@@ -125,19 +123,24 @@
     clearTimelineTimeout();
   });
 
-  $effect(() => {
-    createQuery({
-      queryKey: olderQueryKey,
-      queryFn: undefined,
-      staleTime: Infinity,
-      gcTime: Infinity,
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-    });
+  //svelte-ignore state_referenced_locally
+  createQuery({
+    queryKey: olderQueryKey,
+    queryFn: undefined,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   });
 
   let result = $derived(
-    useTimelineEventList(queryKey, filters, configureOperators, req, relays),
+    useTimelineEventList(
+      queryKey,
+      filters,
+      pipe(tie, uniq(), scanArray()),
+      req,
+      relays,
+    ),
   );
   $effect(() => {
     const currentResult = result;
@@ -268,7 +271,7 @@
       const olderEvents = await firstLoadOlderEvents(
         CONFIG.LOAD_LIMIT,
         newFilters,
-        configureOperators,
+        pipe(tie, uniq(), scanArray()),
         relays,
         handleIncrementalData,
       );
@@ -344,7 +347,7 @@
         fetchAmount,
         filtersWithoutSince,
         untilTime,
-        configureOperators,
+        pipe(tie, uniq(), scanArray()),
         relays,
         (partialData) => {
           if (destroyed || partialData.length === 0) return;

--- a/src/lib/components/renderSnippets/nostr/TimelineList.svelte
+++ b/src/lib/components/renderSnippets/nostr/TimelineList.svelte
@@ -1,4 +1,4 @@
-<!--
+<!--TimelineList.svelte
   メインTL以外のタイムラインコンポーネント
   （グローバルTL、リストTL、ユーザーページのTLなど）
 -->
@@ -136,14 +136,13 @@
     });
   });
 
-  //svelte-ignore state_referenced_locally
-  let result = useTimelineEventList(
-    queryKey,
-    filters,
-    configureOperators,
-    req,
-    relays
+  let result = $derived(
+    useTimelineEventList(queryKey, filters, configureOperators, req, relays),
   );
+  $effect(() => {
+    const currentResult = result;
+    return () => currentResult.destroy();
+  });
   let globalData = $derived(result.data);
   let status = $derived(result.status);
   let errorData = $derived(result.error);
@@ -180,7 +179,7 @@
   function mergeEventsToMap(
     current: EventPacket[] | null | undefined,
     older: EventPacket[] | undefined,
-    partial: EventPacket[] | undefined
+    partial: EventPacket[] | undefined,
   ): void {
     allUniqueEventsMap.clear();
     if (destroyed) return;
@@ -208,7 +207,7 @@
 
       // Mapから配列を生成してソート
       const sortedEvents = Array.from(allUniqueEventsMap.values()).sort(
-        (a, b) => b.created_at - a.created_at
+        (a, b) => b.created_at - a.created_at,
       );
 
       const startIndex = Math.max(0, viewIndex);
@@ -271,7 +270,7 @@
         newFilters,
         configureOperators,
         relays,
-        handleIncrementalData
+        handleIncrementalData,
       );
       if (destroyed) return;
       if (olderEvents.length > 0) {
@@ -361,7 +360,7 @@
           }
 
           updateViewEvent(partialData);
-        }
+        },
       );
       if (destroyed) return;
       if (olderEvents.length > 0) {
@@ -404,11 +403,11 @@
 
         const existingIds = new Set(oldData.map((pk) => pk.event.id));
         const uniqueEvents = events.filter(
-          (pk) => !existingIds.has(pk.event.id)
+          (pk) => !existingIds.has(pk.event.id),
         );
 
         return sortEventPackets([...oldData, ...uniqueEvents]);
-      }
+      },
     );
   }
 

--- a/src/lib/components/renderSnippets/nostr/UniqueEventList.svelte
+++ b/src/lib/components/renderSnippets/nostr/UniqueEventList.svelte
@@ -40,6 +40,10 @@
   }: Props = $props();
 
   let result = $derived(useUniqueEventList(queryKey, filters, req));
+  $effect(() => {
+    const currentResult = result;
+    return () => currentResult.destroy();
+  });
   let data = $derived(result.data);
   let status = $derived(result.status);
   let errorData = $derived(result.error);

--- a/src/lib/func/nostr.ts
+++ b/src/lib/func/nostr.ts
@@ -32,7 +32,7 @@ import {
   createUniq,
 } from "rx-nostr";
 import { writable, derived, get, type Readable } from "svelte/store";
-import { type Observable, type OperatorFunction } from "rxjs";
+import { Subscription, type Observable, type OperatorFunction } from "rxjs";
 import * as Nostr from "nostr-typedef";
 import {
   bookmark,
@@ -323,10 +323,9 @@ export function useMainTimelineReq(
 ): {
   data: Readable<EventPacket | EventPacket[] | undefined>;
   status: Readable<ReqStatus>;
-  error: Readable<Error>;
+  error: Readable<Error | null>;
+  destroy: () => void;
 } {
-  //console.log(filters);
-
   const _queryClient = queryClient;
 
   if (!_queryClient) {
@@ -334,21 +333,27 @@ export function useMainTimelineReq(
   }
 
   const status = writable<ReqStatus>("loading");
-  const error = writable<Error>();
+  const error = writable<Error | null>(null);
 
-  const obs: Observable<EventPacket | EventPacket[]> = get(app)
-    .rxNostr.use(req)
-    .pipe(metadata(), bookmark(), operator);
+  let subscription: Subscription | undefined;
 
   const query = createQuery({
     queryKey: queryKey,
     gcTime: Infinity,
     staleTime: Infinity,
     queryFn: (): Promise<EventPacket | EventPacket[]> => {
-      return new Promise((resolve, reject) => {
-        let fulfilled = false;
+      subscription?.unsubscribe();
 
-        obs.subscribe({
+      return new Promise((resolve, reject) => {
+        const obs: Observable<EventPacket | EventPacket[]> = get(app)
+          .rxNostr.use(req)
+          .pipe(metadata(), bookmark(), operator);
+
+        let fulfilled = false;
+        status.set("loading");
+        error.set(null);
+
+        subscription = obs.subscribe({
           next: (v: EventPacket | EventPacket[]) => {
             if (fulfilled) {
               _queryClient.setQueryData(queryKey, v);
@@ -362,6 +367,10 @@ export function useMainTimelineReq(
             console.error("[rx-nostr]", e);
             status.set("error");
             error.set(e);
+            if (!fulfilled) {
+              reject(e);
+              fulfilled = true;
+            }
           },
         });
         changeMainEmit(filters);
@@ -372,21 +381,15 @@ export function useMainTimelineReq(
   return {
     data: derived(query, ($query) => $query.data, undefined),
     status: derived([query, status], ([$query, $status]) => {
-      if ($query.isSuccess) {
-        return "success";
-      } else if ($query.isError) {
-        return "error";
-      } else {
-        return $status;
-      }
+      if ($query.isSuccess) return "success";
+      if ($query.isError) return "error";
+      return $status;
     }),
-    error: derived([query, error], ([$query, $error]) => {
-      if ($query.isError) {
-        return $query.error;
-      } else {
-        return $error;
-      }
+    error: derived([query, error], ([$query, $e]) => {
+      if ($query.isError) return $query.error;
+      return $e;
     }),
+    destroy: () => subscription?.unsubscribe(),
   };
 }
 
@@ -404,13 +407,13 @@ export function publishEvent(ev: Nostr.EventParameters) {
     console.log("error");
     throw Error();
   }
-  _rxNostr.send(ev).subscribe((packet) => {
-    /* addDebugLog(
+  /* _rxNostr.send(ev).subscribe((packet) => {
+    addDebugLog(
       `リレー ${packet.from} への送信が ${
         packet.ok ? "成功" : "失敗"
       } しました。`
-    ); */
-  });
+    ); 
+  });*/
 }
 
 export async function promisePublishSignedEvent(

--- a/src/lib/func/nostr.ts
+++ b/src/lib/func/nostr.ts
@@ -943,5 +943,5 @@ export function usePaginatedReq(
     }
   })();
 
-  return { data, status, error };
+  return { data, status, error, destroy: () => {} };
 }

--- a/src/lib/func/upload.test.ts
+++ b/src/lib/func/upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, test } from "vitest";
-import { checkImageQuality, formatFileSize, removeExif } from "./upload";
+import { checkImageQuality, formatFileSize } from "./upload";
 import fs from "fs";
 import path from "path";
 test("", () => {});

--- a/src/lib/stores/useContacts.ts
+++ b/src/lib/stores/useContacts.ts
@@ -22,7 +22,7 @@ export function useContacts(
         }> &
         RxReqOverable &
         RxReqPipeable)
-    | undefined
+    | undefined,
 ): ReqResult<EventPacket> {
   return useReplaceableEvent(rxNostr, queryKey, pubkey, 3, req);
 }

--- a/src/lib/stores/useEvent.ts
+++ b/src/lib/stores/useEvent.ts
@@ -1,3 +1,4 @@
+//useEvent.ts
 import type { QueryKey } from "@tanstack/svelte-query";
 import {
   type EventPacket,
@@ -23,12 +24,12 @@ export function useEvent(
         RxReqOverable &
         RxReqPipeable)
     | undefined,
-  relays?: string[] | undefined
+  relays?: string[] | undefined,
 ): ReqResult<EventPacket> {
   const filters = [{ ids: [id], limit: 1 }];
   const operator = pipe(tie);
   return useReq(
     { queryKey, filters, operator, req },
-    relays
+    relays,
   ) as ReqResult<EventPacket>;
 }

--- a/src/lib/stores/useEvent.ts
+++ b/src/lib/stores/useEvent.ts
@@ -16,7 +16,7 @@ import { tie } from "./stores";
 export function useEvent(
   queryKey: QueryKey,
   id: string,
-  req?:
+  req:
     | (RxReq<"backward"> &
         RxReqEmittable<{
           relays: string[];

--- a/src/lib/stores/useEventSave.ts
+++ b/src/lib/stores/useEventSave.ts
@@ -24,7 +24,7 @@ export function useEventSave(
         }> &
         RxReqOverable &
         RxReqPipeable)
-    | undefined
+    | undefined,
 ): ReqResult<EventPacket> {
   const filters = [{ ids: [id], limit: 1 }];
   const operator = pipe(tie, uniq());

--- a/src/lib/stores/useLatestEvent.ts
+++ b/src/lib/stores/useLatestEvent.ts
@@ -1,3 +1,4 @@
+//useLatestEvent.ts
 import { useReq } from "$lib/func/useReq";
 import type { ReqResult } from "$lib/types";
 import type { QueryKey } from "@tanstack/svelte-query";
@@ -24,11 +25,11 @@ export function useLatestEvent(
         RxReqOverable &
         RxReqPipeable)
     | undefined,
-  relays?: string[] | undefined
+  relays?: string[] | undefined,
 ): ReqResult<EventPacket> {
   const operator = pipe(tie, latest());
   return useReq(
     { queryKey, filters, operator, req },
-    relays
+    relays,
   ) as ReqResult<EventPacket>;
 }

--- a/src/lib/stores/useLatestEvent.ts
+++ b/src/lib/stores/useLatestEvent.ts
@@ -10,7 +10,7 @@ import type {
   RxReqOverable,
   RxReqPipeable,
 } from "rx-nostr";
-import { latest } from "rx-nostr";
+import { latest, uniq } from "rx-nostr";
 import { pipe } from "rxjs";
 import { tie } from "./stores";
 
@@ -27,7 +27,7 @@ export function useLatestEvent(
     | undefined,
   relays?: string[] | undefined,
 ): ReqResult<EventPacket> {
-  const operator = pipe(tie, latest());
+  const operator = pipe(tie, latest(), uniq());
   return useReq(
     { queryKey, filters, operator, req },
     relays,

--- a/src/lib/stores/useMetadata.ts
+++ b/src/lib/stores/useMetadata.ts
@@ -26,7 +26,7 @@ export function useMetadata(
   initData?: EventPacket | EventPacket[] | undefined,
   staleTime: number = Infinity,
   initialDataUpdatedAt: number | undefined = undefined,
-  refetchInterval: number = Infinity
+  refetchInterval: number = Infinity,
 ): ReqResult<EventPacket> {
   return useReplaceableEvent(
     rxNostr,
@@ -37,6 +37,6 @@ export function useMetadata(
     initData,
     staleTime,
     initialDataUpdatedAt,
-    refetchInterval
+    refetchInterval,
   );
 }

--- a/src/lib/stores/useRelaySet.ts
+++ b/src/lib/stores/useRelaySet.ts
@@ -32,7 +32,7 @@ export function useRelaySet(
         }> &
         RxReqOverable &
         RxReqPipeable)
-    | undefined
+    | undefined,
 ): ReqResult<DefaultRelayConfig[]> | undefined {
   // console.log(relaySearchRelays, queryKey);
   setRelays(relaySearchRelays);
@@ -52,13 +52,14 @@ export function useRelaySet(
     data: transformedData,
     status: reqResult.status,
     error: reqResult.error,
+    destroy: () => {},
   };
 }
 let kind10002: Nostr.Event;
 let kind3: Nostr.Event;
 let relay: DefaultRelayConfig[] = [];
 export function toRelaySet(
-  value: EventPacket | EventPacket[] | undefined | null
+  value: EventPacket | EventPacket[] | undefined | null,
 ): DefaultRelayConfig[] {
   // console.log(value);
   if (!value) {

--- a/src/lib/stores/useRelaySet.ts
+++ b/src/lib/stores/useRelaySet.ts
@@ -25,14 +25,12 @@ import { debugError, debugInfo } from "$lib/components/Debug/debug";
 export function useRelaySet(
   queryKey: QueryKey,
   filters: Filter[],
-  req?:
-    | (RxReq<"backward"> &
-        RxReqEmittable<{
-          relays: string[];
-        }> &
-        RxReqOverable &
-        RxReqPipeable)
-    | undefined,
+  req: RxReq<"backward"> &
+    RxReqEmittable<{
+      relays: string[];
+    }> &
+    RxReqOverable &
+    RxReqPipeable,
 ): ReqResult<DefaultRelayConfig[]> | undefined {
   // console.log(relaySearchRelays, queryKey);
   setRelays(relaySearchRelays);

--- a/src/lib/stores/useReplaceableEvent.ts
+++ b/src/lib/stores/useReplaceableEvent.ts
@@ -29,13 +29,13 @@ export function useReplaceableEvent(
   initData?: EventPacket | EventPacket[] | undefined,
   staleTime: number = Infinity,
   initialDataUpdatedAt: number | undefined = undefined,
-  refetchInterval: number = Infinity
+  refetchInterval: number = Infinity,
 ): ReqResult<EventPacket> {
   const filters = [{ kinds: [kind], authors: [pubkey], limit: 1 }];
   const operator = pipe(
     tie,
     latest(),
-    debounceTime(1000) // 変化が止まるまで待つ
+    debounceTime(1000), // 変化が止まるまで待つ
     //take(1) // 最初の1回だけ流す
   );
 
@@ -53,6 +53,6 @@ export function useReplaceableEvent(
       gcTime: staleTime,
       initialDataUpdatedAt,
       refetchInterval,
-    }
+    },
   ) as ReqResult<EventPacket>;
 }

--- a/src/lib/stores/useReplaceableEventList.ts
+++ b/src/lib/stores/useReplaceableEventList.ts
@@ -18,14 +18,12 @@ export function useReplaceableEventList(
   queryKey: QueryKey,
   pubkey: string,
   kind: number,
-  req?:
-    | (RxReq<"backward"> &
-        RxReqEmittable<{
-          relays: string[];
-        }> &
-        RxReqOverable &
-        RxReqPipeable)
-    | undefined
+  req: RxReq<"backward"> &
+    RxReqEmittable<{
+      relays: string[];
+    }> &
+    RxReqOverable &
+    RxReqPipeable,
 ): ReqResult<EventPacket[]> {
   // TODO: Add npub support
   const filters = [{ kinds: [kind], authors: [pubkey] }];
@@ -38,7 +36,7 @@ export function useReplaceableEventList(
       return tag ? tag[1] : null;
     }), */
 
-    scanArray()
+    scanArray(),
   );
   return useReq({ queryKey, filters, operator, req }) as ReqResult<
     EventPacket[]

--- a/src/lib/stores/useUniqueEventList.ts
+++ b/src/lib/stores/useUniqueEventList.ts
@@ -25,7 +25,7 @@ export function useUniqueEventList(
         }> &
         RxReqOverable &
         RxReqPipeable)
-    | undefined
+    | undefined,
 ): ReqResult<EventPacket[]> {
   const operator = pipe(tie, uniq(), scanArray());
   return useReq({ queryKey, filters, operator, req }) as ReqResult<

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,10 +51,12 @@ export const timelineFilterInit: TimelineFilter = {
   },
 };
 
+// types.ts に追加
 export interface ReqResult<A> {
   data: Readable<A | undefined | null>;
   status: Readable<ReqStatus>;
   error: Readable<Error | null>;
+  destroy: () => void; // 追加
 }
 
 export interface UseConnectionsOpts {

--- a/src/routes/[nostr=nostr]/+page.server.ts
+++ b/src/routes/[nostr=nostr]/+page.server.ts
@@ -1,6 +1,7 @@
 import { redirect } from "@sveltejs/kit";
+import type { PageServerLoad } from "./$types";
 
-export const load = async ({ params }) => {
+export const load: PageServerLoad = async ({ params }) => {
   const { nostr } = params;
   let decodedNostr: string;
 

--- a/src/routes/global/+page.svelte
+++ b/src/routes/global/+page.svelte
@@ -1,3 +1,4 @@
+<!--/global/+page.svelte-->
 <script lang="ts">
   import { onMount, untrack } from "svelte";
   import { t as _ } from "@konemono/svelte5-i18n";
@@ -11,7 +12,7 @@
   import { usePromiseReq } from "$lib/func/nostr";
   import { generateResultMessage } from "$lib/func/util";
   import { toGlobalRelaySet } from "$lib/stores/useGlobalRelaySet";
-  import { unsucscribeGlobal } from "$lib/func/useReq";
+  import { unsubscribeGlobal } from "$lib/func/useReq";
   import OpenPostWindow from "$lib/components/OpenPostWindow.svelte";
   import Settei from "./Settei.svelte";
   import GlobalDescription from "./GlobalDescription.svelte";
@@ -100,7 +101,7 @@
       if (relaylist.length > 0) {
         queryClient.setQueryData(
           ["globalRelay", lumiSetting.get().pubkey],
-          relaylist
+          relaylist,
         );
         globalRelays = relaylist;
       }
@@ -158,7 +159,7 @@
         operator: pipe(latest()),
       },
       undefined,
-      5000
+      5000,
     );
 
     $nowProgress = false;
@@ -169,7 +170,7 @@
         console.log("[GlobalPage] fetched relay config:", relayList);
         queryClient.setQueryData(
           ["globalRelay", lumiSetting.get().pubkey],
-          relayList
+          relayList,
         );
         globalRelays = relayList;
       }
@@ -213,7 +214,7 @@
     if (relaysFromParams.length > 0) {
       console.log(
         "[GlobalPage] using relays from URL params:",
-        relaysFromParams
+        relaysFromParams,
       );
       globalRelays = relaysFromParams;
     } else {
@@ -251,7 +252,7 @@
               Array.isArray(tag) &&
               tag[0] === "p" &&
               tag.length > 1 &&
-              tag[1] !== (note?.pubkey || "")
+              tag[1] !== (note?.pubkey || ""),
           );
           if (hasPTags) return false;
         }
@@ -295,7 +296,7 @@
     openGlobalTimeline = false;
 
     // グローバルタイムラインの購読を解除
-    unsucscribeGlobal();
+    unsubscribeGlobal();
   });
 
   // リレー設定が変更されたときにタイムラインを再初期化

--- a/src/routes/global/GlobalTimeline.svelte
+++ b/src/routes/global/GlobalTimeline.svelte
@@ -1,3 +1,4 @@
+<!--GlobalTimeline.svelte-->
 <script lang="ts">
   import { afterNavigate } from "$app/navigation";
   import EventCard from "$lib/components/NostrElements/kindEvents/EventCard/EventCard.svelte";
@@ -38,7 +39,7 @@
       "[GlobalTimeline] since initialized:",
       since,
       "current time:",
-      Math.floor(Date.now() / 1000)
+      Math.floor(Date.now() / 1000),
     );
   };
 
@@ -88,7 +89,7 @@
 
     if (isInitializing) {
       console.log(
-        "[GlobalTimeline] navigation during initialization, skipping"
+        "[GlobalTimeline] navigation during initialization, skipping",
       );
       return;
     }

--- a/src/routes/post/+page.server.ts
+++ b/src/routes/post/+page.server.ts
@@ -1,6 +1,6 @@
 // +page.server.ts
 
-import { fail } from "@sveltejs/kit";
+import { fail, type RequestEvent } from "@sveltejs/kit";
 
 let data: { title: any; text: any; url?: any; media?: any } = {
   title: "",
@@ -8,7 +8,7 @@ let data: { title: any; text: any; url?: any; media?: any } = {
 };
 
 export const actions = {
-  default: async ({ request }) => {
+  default: async ({ request }: RequestEvent) => {
     try {
       const formData = await request.formData();
 

--- a/src/routes/search/SearchResult.svelte
+++ b/src/routes/search/SearchResult.svelte
@@ -10,7 +10,7 @@
   import OpenPostWindow from "$lib/components/OpenPostWindow.svelte";
   import SearchResultList from "./SearchResultList.svelte";
   import { defaultRelays, queryClient } from "$lib/stores/stores";
-  import { unsucscribeSearch } from "$lib/func/useReq";
+  import { unsubscribeSearch } from "$lib/func/useReq";
 
   let amount = 50;
   let viewIndex = 0;
@@ -26,7 +26,7 @@
 
   onDestroy(() => {
     console.log("onDestroy");
-    unsucscribeSearch();
+    unsubscribeSearch();
     // queryClient.cancelQueries({
     //   queryKey: ["search"],
     // });

--- a/src/routes/search/SearchResultList.svelte
+++ b/src/routes/search/SearchResultList.svelte
@@ -1,3 +1,4 @@
+<!--SearchResultList.svelte-->
 <script lang="ts">
   import { afterNavigate } from "$app/navigation";
   import {
@@ -85,7 +86,7 @@
     tie,
     uniq(),
     userStatus(),
-    /* reactionCheck(), */ scanArray()
+    /* reactionCheck(), */ scanArray(),
   );
   $inspect(filters[0].until);
   let result = $derived(
@@ -98,15 +99,22 @@
           })),
           operator,
           req,
-          relays
+          relays,
         )
       : //untilがあったら、未来の投稿はいらないから適当にウメトク
         {
           data: undefined,
           status: readable("loading" as ReqStatus),
           error: undefined,
-        }
+          destroy: () => {}, // 追加
+        },
   );
+
+  $effect(() => {
+    const currentResult = result;
+    return () => currentResult?.destroy();
+  });
+
   let data = $derived(result.data);
   let status = $derived(result.status);
   let errorData = $derived(result.error);
@@ -127,7 +135,7 @@
   function dataChange(
     data: EventPacket[] | null | undefined,
     index: number,
-    progress: boolean
+    progress: boolean,
   ) {
     console.log("dataChange");
     if ((data && index >= 0) || !progress) {
@@ -160,7 +168,7 @@
         const dedupMap = new Map(merged.map((p) => [p.event.id, p]));
 
         return sortEventPackets(Array.from(dedupMap.values()));
-      }
+      },
     );
   }
   async function init() {
@@ -174,7 +182,7 @@
         ...filter,
 
         until: filter.until === undefined ? now() - 15 * 60 : filter.until,
-      }))
+      })),
     );
     await waitForRelayReady({ maxWaitTime: 5000 }); // 最大5秒待つ
     const older = await firstLoadOlderEvents(
@@ -187,7 +195,7 @@
         if (partialData.length === 0) return;
         updateViewEvent(partialData);
       },
-      5000
+      5000,
     );
 
     if (older.length > 0) {
@@ -231,7 +239,7 @@
 
           updateViewEvent(partialData);
         },
-        5000
+        5000,
       );
       //console.log(older);
       if (older.length > 0) {
@@ -282,9 +290,9 @@
           [...allEvents, ...(partialData || [])].map((event) => [
             event.event.id,
             event.event,
-          ])
-        ).values()
-      )
+          ]),
+        ).values(),
+      ),
     );
     const allEv = uniqueEvents.filter(eventFilter);
     if (!partialData) {


### PR DESCRIPTION
- queryの期限キレたあと取り直せるように
```
const obs: Observable<EventPacket | EventPacket[]> = get(app)
    .rxNostr.use(req)
    .pipe(metadata(), bookmark(), operator);
```
をcreateQueryの中でセットする。

とかなんとかやってたけどなんか同じイベントがTLに現れたら表示できなかったりしてうまくいってない。
