### PR TITLE
検索ページの挙動が不安定だったりクエリが反映されなかったりしたので修正

### DIFF
--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -55,6 +55,13 @@
       isMount = true;
       init();
     }
+    // フォローリスト取得前にクエリが変更されると反映されないので取得時にも反映
+    const unsubscribe = followList.subscribe((value) => {
+      if (searchWord) {
+        createFilter(searchWord);
+      }
+    });
+    return unsubscribe;
   });
 
   async function waitForDefaultRelays(maxWaitTime: number) {

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -72,12 +72,12 @@
   }
 
   async function init() {
-    setSearchRelay();
-
     // +page.tsから受け取ったデータを使用
     searchWord = data.searchWord;
     followee = data.followee;
     excludeProxy = data.excludeProxy;
+
+    await setSearchRelay();
 
     // 検索ワードがある場合は検索を実行
     if (searchWord) {

--- a/src/routes/search/+page.ts
+++ b/src/routes/search/+page.ts
@@ -31,7 +31,7 @@ export const load: PageLoad = ({ url }) => {
   let searchWord = "";
   let followee = false;
   let excludeProxy = false;
-  let shouldLoad = true;
+  let shouldLoad = false;
 
   // 新しい形式が存在するかチェック
   if (qParam) {

--- a/src/routes/search/SearchOption.svelte
+++ b/src/routes/search/SearchOption.svelte
@@ -138,7 +138,7 @@
   }
 
   async function handleClickShare() {
-    const shareData = { url: sharaParam() };
+    const shareData = { url: buildParam().toString() };
     try {
       await navigator.share(shareData);
     } catch (error: any) {
@@ -153,7 +153,7 @@
     }
   }
 
-  function sharaParam() {
+  function buildParam() {
     const url = new URL(page.url.origin + page.url.pathname);
     const params = url.searchParams;
 
@@ -163,10 +163,10 @@
       params.delete("q");
     }
 
-    followee ? params.set("f", "1") : params.delete("f");
-    excludeProxy ? params.set("x", "1") : params.delete("x");
+    followee ? params.set("followee", "1") : params.delete("followee");
+    excludeProxy ? params.set("excludeProxy", "1") : params.delete("excludeProxy");
 
-    return url.toString();
+    return url;
   }
 
   /* function handleResetValue() {
@@ -177,17 +177,7 @@
   function handleUnifiedSearch() {
     if (searchWord || "".trim()) {
       // URLパラメータを更新
-      const url = new URL(window.location.href);
-      if (searchWord && searchWord.trim()) {
-        url.searchParams.set("q", searchWord.trim());
-      } else {
-        url.searchParams.delete("q");
-      }
-
-      followee ? url.searchParams.set("f", "1") : url.searchParams.delete("f");
-      excludeProxy
-        ? url.searchParams.set("x", "1")
-        : url.searchParams.delete("x");
+      const url = new URL(buildParam());
 
       pushState(url.toString(), {});
 

--- a/src/routes/search/SearchOption.svelte
+++ b/src/routes/search/SearchOption.svelte
@@ -177,7 +177,7 @@
   function handleUnifiedSearch() {
     if (searchWord || "".trim()) {
       // URLパラメータを更新
-      const url = new URL(buildParam());
+      const url = buildParam();
 
       pushState(url.toString(), {});
 


### PR DESCRIPTION
- 検索実行時にURLに反映されるパラメータが古い物になっていて常にチェック外れていたので新しい物に変更
    - 共有用のパラメータ生成と共通の処理に変えてるので問題があれば戻します
- 検索リレーが設定される前に検索が走るので、設定を待つようにした
- フォローリスト取得前にクエリが変更されると反映されないので取得時にも反映するように変更
    - こちらもこの処理が妥当かが分からないです(恐らくフォローリスト取得が遅すぎると反映されないケースがある)