### PR TITLE
fix: REQ object passed from outside is disposed

### DIFF
--- a/src/lib/components/SettingsElements/Kind30078.svelte
+++ b/src/lib/components/SettingsElements/Kind30078.svelte
@@ -102,7 +102,6 @@
           },
         ],
         operator: pipe(latest()),
-        req: undefined,
         initData: undefined,
       },
       relays.map(({ url, read, write }) => url),

--- a/src/lib/components/renderSnippets/nostr/reaction/AllReactions.svelte
+++ b/src/lib/components/renderSnippets/nostr/reaction/AllReactions.svelte
@@ -3,27 +3,13 @@
   import type { ReqResult, ReqStatus } from "$lib/types";
 
   import type Nostr from "nostr-typedef";
-  import type {
-    EventPacket,
-    RxReq,
-    RxReqEmittable,
-    RxReqOverable,
-    RxReqPipeable,
-  } from "rx-nostr";
+  import type { EventPacket } from "rx-nostr";
   import { untrack } from "svelte";
   import { readable } from "svelte/store";
 
   interface Props {
     id?: string | undefined;
     atag?: string | undefined;
-    req?:
-      | (RxReq<"backward"> &
-          RxReqEmittable<{
-            relays: string[];
-          }> &
-          RxReqOverable &
-          RxReqPipeable)
-      | undefined;
     error?: import("svelte").Snippet<[Error]>;
     nodata?: import("svelte").Snippet;
     loading?: import("svelte").Snippet;
@@ -42,7 +28,6 @@
   }
 
   let {
-    req = undefined,
     id = undefined,
     atag = undefined,
 
@@ -52,7 +37,7 @@
     children,
   }: Props = $props();
 
-  let result = $derived(useAllReactions(id, atag, req));
+  let result = $derived(useAllReactions(id, atag));
 
   // debounce用の状態
   let debounceTimeoutId: NodeJS.Timeout | undefined = undefined;

--- a/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
+++ b/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
@@ -7,10 +7,6 @@
   import {
     type DefaultRelayConfig,
     type EventPacket,
-    type RxReq,
-    type RxReqEmittable,
-    type RxReqOverable,
-    type RxReqPipeable,
     latest,
     uniq,
   } from "rx-nostr";
@@ -31,21 +27,12 @@
 
   interface Props {
     paramRelays: string[] | undefined;
-    req?:
-      | (RxReq<"backward"> &
-          RxReqEmittable<{
-            relays: string[];
-          }> &
-          RxReqOverable &
-          RxReqPipeable)
-      | undefined;
     error?: Snippet<[Error]>;
     loading?: Snippet<[string]>;
     contents?: Snippet;
   }
 
   let {
-    req = undefined,
     paramRelays = undefined,
     error,
     loading,
@@ -172,7 +159,7 @@
     // フェッチ
     $app.rxNostr.setDefaultRelays(defaultRelays);
     const result = await usePromiseReq(
-      { filters, operator: pipe(uniq(), latest()), req },
+      { filters, operator: pipe(uniq(), latest()) },
       defaultRelays,
       3000,
       (packets: EventPacket[]) => {

--- a/src/lib/components/renderSnippets/nostr/timelineList.ts
+++ b/src/lib/components/renderSnippets/nostr/timelineList.ts
@@ -10,8 +10,6 @@ import {
 import { defaultRelays } from "$lib/stores/stores";
 import type { Filter } from "nostr-typedef";
 import {
-  createRxBackwardReq,
-  uniq,
   type DefaultRelayConfig,
   type EventPacket,
 } from "rx-nostr";
@@ -61,23 +59,17 @@ export async function loadOlderEvents(
 
   //console.log(newFilters, sift, operator);
 
-  // Create request and operator pipeline
-  const newReq = createRxBackwardReq();
-
   // Fetch events
   const olderEvents = await usePromiseReq(
     {
       operator,
       filters: newFilters,
-      req: newReq,
     },
     relays,
     timeout,
     onData,
     sift
   );
-
-  newReq.over();
   // Filter events by timestamp
   const filteredOlderEvents = olderEvents.filter(
     (packet) => packet.event.created_at <= until
@@ -106,14 +98,11 @@ export async function firstLoadOlderEvents(
   onData?: (data: EventPacket[]) => void, // 処理途中のデータを受け取るコールバック
   timeout?: number
 ): Promise<EventPacket[]> {
-  const newReq = createRxBackwardReq();
-
   // Fetch events with longer timeout (4000ms)
   const olderEvents = await usePromiseReq(
     {
       operator,
       filters,
-      req: newReq,
     },
     relays,
     timeout,

--- a/src/lib/func/nostr.ts
+++ b/src/lib/func/nostr.ts
@@ -561,7 +561,6 @@ export function usePromiseReq(
   {
     filters,
     operator,
-    req,
     initData = [],
   }: UsePromiseReqOpts<EventPacket[] | EventPacket>,
   relays: string[] | undefined,
@@ -575,18 +574,7 @@ export function usePromiseReq(
     throw Error("No default relays available");
   }
 
-  let _req: RxReq<"backward"> &
-    RxReqEmittable<{
-      relays: string[];
-    }> &
-    RxReqOverable &
-    RxReqPipeable;
-
-  if (req) {
-    _req = req;
-  } else {
-    _req = createRxBackwardReq();
-  }
+  const _req = createRxBackwardReq();
 
   // 初期データが配列でない場合は、配列に変換
   let accumulatedData: EventPacket[] = Array.isArray(initData)
@@ -790,15 +778,10 @@ export function useMediaPromiseReq(
 export function usePaginatedReq(
   {
     filters,
-    req,
     limit = 300,
     maxLoop = 50,
   }: {
     filters: Array<any>;
-    req?: RxReq<"backward"> &
-      RxReqEmittable<{ relays: string[] }> &
-      RxReqOverable &
-      RxReqPipeable;
     limit?: number;
     maxLoop?: number;
   },
@@ -823,7 +806,7 @@ export function usePaginatedReq(
           console.log(pagedFilter);
 
           const chunk = await usePromiseReq(
-            { filters: [pagedFilter], operator: scanArray(), req },
+            { filters: [pagedFilter], operator: scanArray() },
             relays,
             timeout,
             (intermediateData) => {

--- a/src/lib/func/zap.ts
+++ b/src/lib/func/zap.ts
@@ -232,7 +232,6 @@ export async function getZapRelay(pubkey: string): Promise<string[]> {
           },
         ],
         operator: pipe(latest(), uniq()),
-        req: undefined,
       },
       undefined,
     );

--- a/src/lib/stores/useAllReactions.ts
+++ b/src/lib/stores/useAllReactions.ts
@@ -1,10 +1,4 @@
-import {
-  type EventPacket,
-  type RxReq,
-  type RxReqEmittable,
-  type RxReqOverable,
-  type RxReqPipeable,
-} from "rx-nostr";
+import type { EventPacket } from "rx-nostr";
 import type { ReqResult } from "$lib/types.js";
 
 import { usePaginatedReq } from "$lib/func/nostr";
@@ -12,11 +6,6 @@ import { usePaginatedReq } from "$lib/func/nostr";
 export function useAllReactions(
   id: string | undefined,
   atag: string | undefined,
-  req?:
-    | RxReq<"backward"> &
-        RxReqEmittable<{ relays: string[] }> &
-        RxReqOverable &
-        RxReqPipeable
 ): ReqResult<EventPacket[]> {
   const filters =
     atag !== undefined
@@ -32,5 +21,5 @@ export function useAllReactions(
       : [];
 
   // そのまま usePaginatedReq を返す
-  return usePaginatedReq({ filters, req, limit: 500 }, undefined);
+  return usePaginatedReq({ filters, limit: 500 }, undefined);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,13 +79,6 @@ export interface UseForwardReqOpts<A> {
 export interface UsePromiseReqOpts<A> {
   filters: Nostr.Filter[];
   operator: OperatorFunction<EventPacket, A>;
-  req?: RxReq<"backward"> &
-    RxReqEmittable<{
-      relays: string[];
-    }> &
-    RxReqOverable &
-    RxReqPipeable;
-
   initData?: A;
 }
 export interface UseReqOpts2<A> {

--- a/src/routes/notifications/NotificationList.svelte
+++ b/src/routes/notifications/NotificationList.svelte
@@ -173,7 +173,7 @@
 
       // Load initial events
       const olderEvents = await usePromiseReq(
-        { filters, operator, req: undefined },
+        { filters, operator },
         undefined,
       );
 


### PR DESCRIPTION
#1049 の修正に際して、外側からreqを渡した際に破壊する問題が発生したので、そもそも渡せないように変更しました。