### PR TITLE
Support Blossom server list (kind 10063)

### DIFF
--- a/src/lib/components/Elements/UploaderSelect.svelte
+++ b/src/lib/components/Elements/UploaderSelect.svelte
@@ -14,7 +14,7 @@
   import { usePromiseReq } from "$lib/func/nostr";
   import { pipe } from "rxjs";
   import { latest } from "rx-nostr";
-
+import { normalizeURL } from "nostr-tools/utils";
   function getHostname(url: string) {
     try {
       return new URL(url).hostname;

--- a/src/lib/components/Elements/UploaderSelect.svelte
+++ b/src/lib/components/Elements/UploaderSelect.svelte
@@ -59,7 +59,7 @@
       );
       if (packets.length > 0) {
         userBlossomServers = packets[0].event.tags
-          .filter((tag) => tag[0] === "server" && tag[1])
+          .filter((tag): tag is [string, string, ...string[]] => tag[0] === "server" && !!tag[1])
           .map((tag) => tag[1]);
       }
     } catch (error) {

--- a/src/lib/components/Elements/UploaderSelect.svelte
+++ b/src/lib/components/Elements/UploaderSelect.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createSelect, melt } from "@melt-ui/svelte";
   import { fade } from "svelte/transition";
+  import { onMount } from "svelte";
   import { STORAGE_KEYS } from "$lib/func/localStorageKeys";
   import {
     nip96MediaUploader,
@@ -9,7 +10,10 @@
   import { Check, ChevronDown } from "lucide-svelte";
   import type { UploaderOption, UploaderType } from "$lib/types";
 
-  import { uploader } from "$lib/stores/globalRunes.svelte";
+  import { uploader, lumiSetting } from "$lib/stores/globalRunes.svelte";
+  import { usePromiseReq } from "$lib/func/nostr";
+  import { pipe } from "rxjs";
+  import { latest } from "rx-nostr/src";
 
   function getHostname(url: string) {
     try {
@@ -19,13 +23,49 @@
     }
   }
 
-  const groupedOptions: Record<UploaderType, UploaderOption[]> = {
-    nip96: nip96MediaUploader.map((url) => ({ type: "nip96", address: url })),
-    blossom: blossomMediaUploader.map((url) => ({
-      type: "blossom",
+  // ユーザーの kind 10063 (Blossom サーバーリスト / BUD-03) から取得したサーバー
+  let userBlossomServers: string[] = $state([]);
+
+  const groupedOptions: Record<UploaderType, UploaderOption[]> = $derived({
+    nip96: nip96MediaUploader.map((url) => ({
+      type: "nip96" as const,
       address: url,
     })),
-  };
+    blossom: [
+      // ユーザー自身のサーバーを優先し、ハードコードのリストと重複を除く
+      ...userBlossomServers,
+      ...blossomMediaUploader.filter(
+        (url) => !userBlossomServers.includes(url),
+      ),
+    ].map((url) => ({
+      type: "blossom" as const,
+      address: url,
+    })),
+  });
+
+  onMount(async () => {
+    const pubkey = lumiSetting.get().pubkey;
+    if (!pubkey) {
+      return;
+    }
+    try {
+      const packets = await usePromiseReq(
+        {
+          filters: [{ kinds: [10063], authors: [pubkey], limit: 1 }],
+          operator: pipe(latest()),
+        },
+        undefined,
+        5000,
+      );
+      if (packets.length > 0) {
+        userBlossomServers = packets[0].event.tags
+          .filter((tag) => tag[0] === "server" && tag[1])
+          .map((tag) => tag[1]);
+      }
+    } catch (error) {
+      console.error("Failed to fetch kind 10063 blossom server list:", error);
+    }
+  });
 
   const {
     elements: { trigger, menu, option, group, groupLabel, label },

--- a/src/lib/components/Elements/UploaderSelect.svelte
+++ b/src/lib/components/Elements/UploaderSelect.svelte
@@ -13,7 +13,7 @@
   import { uploader, lumiSetting } from "$lib/stores/globalRunes.svelte";
   import { usePromiseReq } from "$lib/func/nostr";
   import { pipe } from "rxjs";
-  import { latest } from "rx-nostr/src";
+  import { latest } from "rx-nostr";
 
   function getHostname(url: string) {
     try {

--- a/src/lib/components/Elements/UploaderSelect.svelte
+++ b/src/lib/components/Elements/UploaderSelect.svelte
@@ -35,7 +35,7 @@
       // ユーザー自身のサーバーを優先し、ハードコードのリストと重複を除く
       ...userBlossomServers,
       ...blossomMediaUploader.filter(
-        (url) => !userBlossomServers.includes(url),
+       (url) => !userBlossomServers.some((u) => normalizeURL(u) === normalizeURL(url)),
       ),
     ].map((url) => ({
       type: "blossom" as const,

--- a/src/lib/func/constants.ts
+++ b/src/lib/func/constants.ts
@@ -118,7 +118,7 @@ export const initLumiMuteByKind: LumiMuteByKind = {
 //https://github.com/TsukemonoGit/NostViewstr/blob/3981eac66c5ec51afa38069a6981410b5a42bc16/src/lib/kind.ts
 export const nostviewstrable = [
   3, 10000, 10001, 10002, 10003, 10004, 10005, 10006, 10007, 10015, 10030,
-  10096, 10101, 10102, 30000, 30001, 30002, 30003, 30004, 30007,
+  10063, 10096, 10101, 10102, 30000, 30001, 30002, 30003, 30004, 30007,
   //30008, ばっじ
   30015, 30030,
 ];


### PR DESCRIPTION
Read the logged-in user's kind 10063 (Blossom server list, BUD-03) from relays and show those servers at the top of the blossom group in the uploader selector, deduped against the built-in list. Also add 10063 to the nostviewstrable kinds so its events get the NostViewstr edit menu.