### PR TITLE
Display NIP-26 delegated notes as the delegator

### DIFF
--- a/src/lib/components/Elements/Delegation.svelte
+++ b/src/lib/components/Elements/Delegation.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { UserRoundCheck } from "lucide-svelte";
+  import { t as _ } from "@konemono/svelte5-i18n";
   import * as nip19 from "nostr-tools/nip19";
 
   // signer: NIP-26 の署名鍵(delegatee)。作者としては表示せず、バッジのツールチップにのみ残す。
@@ -12,13 +13,15 @@
       return signer;
     }
   });
+
+  let label = $derived($_("event.delegation.signedBy", { npub }));
 </script>
 
 <span
   class="absolute top-1 left-0 text-sky-500"
   style={`z-index:${zIndex || 10 + 1}`}
-  title={`NIP-26 delegated · signed by ${npub}`}
-  aria-label={`NIP-26 delegated, signed by ${npub}`}
+  title={label}
+  aria-label={label}
 >
   <UserRoundCheck size={14} class="fill-sky-200" />
 </span>

--- a/src/lib/components/Elements/Delegation.svelte
+++ b/src/lib/components/Elements/Delegation.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { UserRoundCheck } from "lucide-svelte";
+  import * as nip19 from "nostr-tools/nip19";
+
+  // signer: NIP-26 の署名鍵(delegatee)。作者としては表示せず、バッジのツールチップにのみ残す。
+  let { signer, zIndex }: { signer: string; zIndex?: number } = $props();
+
+  let npub = $derived.by(() => {
+    try {
+      return nip19.npubEncode(signer);
+    } catch {
+      return signer;
+    }
+  });
+</script>
+
+<span
+  class="absolute top-1 left-0 text-sky-500"
+  style={`z-index:${zIndex || 10 + 1}`}
+  title={`NIP-26 delegated · signed by ${npub}`}
+  aria-label={`NIP-26 delegated, signed by ${npub}`}
+>
+  <UserRoundCheck size={14} class="fill-sky-200" />
+</span>

--- a/src/lib/components/NostrElements/kindEvents/EventCard/EventCard.svelte
+++ b/src/lib/components/NostrElements/kindEvents/EventCard/EventCard.svelte
@@ -99,9 +99,17 @@
   let delegation = $derived(note ? getDelegation(note) : null);
   // 委任がある場合は委任元(delegator)を実質的な作者として表示する。
   // 署名鍵(note.pubkey)はアクション/id検証用に温存し、ヘッダには出さない。
-  let delegatorMetadata: Nostr.Event | undefined = $state(undefined);
+  let delegatorMetadata = $state<Nostr.Event | undefined>(undefined);
   let authorPubkey = $derived(delegation?.delegator ?? (note?.pubkey || ""));
-  let authorMetadata = $derived(delegation ? delegatorMetadata : metadata);
+  // 再利用で委任元が切り替わったとき、前の委任元のメタデータを誤って使わないよう
+  // 取得済みメタデータの pubkey が現在の委任元と一致する場合のみ採用する。
+  let authorMetadata = $derived(
+    delegation
+      ? delegatorMetadata?.pubkey === delegation.delegator
+        ? delegatorMetadata
+        : undefined
+      : metadata,
+  );
   // State variables
   let currentNoteTag: string[] | undefined = $state(undefined);
   let deleted = $state(false);

--- a/src/lib/components/NostrElements/kindEvents/EventCard/EventCard.svelte
+++ b/src/lib/components/NostrElements/kindEvents/EventCard/EventCard.svelte
@@ -56,6 +56,9 @@
   import { getIDbyParam } from "$lib/func/util";
   import Protected from "$lib/components/Elements/Protected.svelte";
   import Muted from "$lib/components/Elements/Muted.svelte";
+  import Delegation from "$lib/components/Elements/Delegation.svelte";
+  import { getDelegation } from "$lib/func/nip26";
+  import Metadata from "$lib/components/renderSnippets/nostr/Metadata.svelte";
 
   // Component props interface
   interface Props {
@@ -92,6 +95,13 @@
   }: Props = $props();
 
   let isProtected = $derived((note?.tags || []).find((tag) => tag[0] === "-"));
+  // NIP-26: 署名検証を通った委任のみ表示
+  let delegation = $derived(note ? getDelegation(note) : null);
+  // 委任がある場合は委任元(delegator)を実質的な作者として表示する。
+  // 署名鍵(note.pubkey)はアクション/id検証用に温存し、ヘッダには出さない。
+  let delegatorMetadata: Nostr.Event | undefined = $state(undefined);
+  let authorPubkey = $derived(delegation?.delegator ?? (note?.pubkey || ""));
+  let authorMetadata = $derived(delegation ? delegatorMetadata : metadata);
   // State variables
   let currentNoteTag: string[] | undefined = $state(undefined);
   let deleted = $state(false);
@@ -244,6 +254,15 @@
       {#if isProtected}
         <Protected {zIndex} />
       {/if}
+      {#if delegation}
+        <!-- 委任元のメタデータを取得してヘッダ表示に使う(この要素自体は何も描画しない) -->
+        <Metadata
+          queryKey={["metadata", delegation.delegator]}
+          pubkey={delegation.delegator}
+          onChange={(m) => (delegatorMetadata = m)}
+        />
+        <Delegation signer={note?.pubkey || ""} {zIndex} />
+      {/if}
       {#if note.kind === 1 || note.kind === 1111}
         <Kind1Note
           {replyUsers}
@@ -252,6 +271,8 @@
           {maxHeight}
           {note}
           {metadata}
+          {authorPubkey}
+          {authorMetadata}
           {mini}
           {displayMenu}
           {depth}
@@ -289,15 +310,15 @@
           {/snippet}
           {#snippet userIcon()}
             <UserPopupMenu
-              pubkey={note?.pubkey || ""}
-              {metadata}
+              pubkey={authorPubkey}
+              metadata={authorMetadata}
               size={20}
               {displayMenu}
               {depth}
             />
           {/snippet}
           {#snippet name()}
-            <ProfileDisplay pubkey={note?.pubkey || ""} {metadata} />
+            <ProfileDisplay pubkey={authorPubkey} metadata={authorMetadata} />
           {/snippet}
 
           {#snippet actionButtons()}
@@ -335,15 +356,15 @@
           {/snippet}
           {#snippet userIcon()}
             <UserPopupMenu
-              pubkey={note?.pubkey || ""}
-              {metadata}
+              pubkey={authorPubkey}
+              metadata={authorMetadata}
               size={20}
               {displayMenu}
               {depth}
             />
           {/snippet}
           {#snippet name()}
-            <ProfileDisplay pubkey={note?.pubkey || ""} {metadata} />
+            <ProfileDisplay pubkey={authorPubkey} metadata={authorMetadata} />
           {/snippet}
 
           {#snippet actionButtons()}

--- a/src/lib/components/NostrElements/kindEvents/EventCard/EventCard.svelte
+++ b/src/lib/components/NostrElements/kindEvents/EventCard/EventCard.svelte
@@ -267,7 +267,12 @@
         <Metadata
           queryKey={["metadata", delegation.delegator]}
           pubkey={delegation.delegator}
-          onChange={(m) => (delegatorMetadata = m)}
+          onChange={(m) => {
+            // 委任元切替後に遅れて届いた古い取得結果で上書きしない
+            if (m.pubkey === delegation?.delegator) {
+              delegatorMetadata = m;
+            }
+          }}
         />
         <Delegation signer={note?.pubkey || ""} {zIndex} />
       {/if}

--- a/src/lib/components/NostrElements/kindEvents/EventCard/Kind1Note.svelte
+++ b/src/lib/components/NostrElements/kindEvents/EventCard/Kind1Note.svelte
@@ -21,6 +21,9 @@
   interface Props {
     note: Nostr.Event;
     metadata?: Nostr.Event | undefined;
+    // NIP-26: 委任時にヘッダ表示に使う作者(委任元)。未指定なら署名者を使う。
+    authorPubkey?: string;
+    authorMetadata?: Nostr.Event | undefined;
     zIndex?: number;
     maxHeight?: number;
     replyTag: string[] | undefined;
@@ -42,6 +45,8 @@
   let {
     note,
     metadata = $bindable(undefined),
+    authorPubkey = undefined,
+    authorMetadata = undefined,
     mini = false,
     depth,
     displayMenu = true,
@@ -58,6 +63,10 @@
   }: Props = $props();
 
   let warning = $derived(checkContentWarning(note?.tags));
+
+  // ヘッダ(アイコン/名前/ステータス)に使う作者。委任時は委任元、通常は署名者。
+  let headerPubkey = $derived(authorPubkey || note?.pubkey || "");
+  let headerMetadata = $derived(authorPubkey ? authorMetadata : metadata);
 
   let isBookmarked: boolean = $derived(
     bookmark10003
@@ -90,8 +99,8 @@
 >
   {#snippet icon()}
     <UserPopupMenu
-      pubkey={note?.pubkey || ""}
-      {metadata}
+      pubkey={headerPubkey}
+      metadata={headerMetadata}
       size={mini ? 20 : 40}
       {displayMenu}
       {depth}
@@ -104,9 +113,9 @@
   {/snippet}
   {#snippet name()}
     <ProfileDisplay
-      pubkey={note?.pubkey || ""}
+      pubkey={headerPubkey}
       kind={note.kind}
-      {metadata}
+      metadata={headerMetadata}
       {kindInfo}
     />
   {/snippet}
@@ -116,7 +125,7 @@
 
   {#snippet status()}
     {#if lumiSetting.value.showUserStatus && showStatus}<ShowStatus
-        pubkey={note?.pubkey || ""}
+        pubkey={headerPubkey}
       />{/if}
   {/snippet}
   {#snippet replyUser()}

--- a/src/lib/func/nip26.ts
+++ b/src/lib/func/nip26.ts
@@ -1,0 +1,90 @@
+import { sha256 } from "@noble/hashes/sha256";
+import { hexToBytes } from "@noble/hashes/utils";
+import { schnorr } from "@noble/curves/secp256k1";
+import type * as Nostr from "nostr-typedef";
+
+/**
+ * Result of a verified NIP-26 delegation.
+ */
+export interface Delegation {
+  /** The delegator's public key (hex) — the account on whose behalf the event was published. */
+  delegator: string;
+  /** The raw conditions query string (e.g. "kind=1&created_at<1700000000"). */
+  conditions: string;
+}
+
+/**
+ * Parses and verifies the NIP-26 `delegation` tag of an event.
+ *
+ * Returns the delegator information only when the delegation token signature is
+ * valid AND the event satisfies the delegation conditions. Returns null otherwise
+ * (no tag, malformed tag, unmet conditions, or bad signature) so that a forged
+ * delegation tag is never displayed as a genuine one.
+ *
+ * @see https://github.com/nostr-protocol/nips/blob/master/26.md
+ */
+export function getDelegation(event: Nostr.Event): Delegation | null {
+  const tag = (event.tags || []).find(
+    (t) => t[0] === "delegation" && t.length >= 4,
+  );
+  if (!tag) return null;
+
+  const [, delegator, conditions, sig] = tag;
+  if (!delegator || !sig) return null;
+
+  // The event must satisfy the delegation conditions.
+  if (!checkConditions(conditions, event)) return null;
+
+  // Verify the delegation token was signed by the delegator.
+  try {
+    const token = `nostr:delegation:${event.pubkey}:${conditions}`;
+    const hash = sha256(new TextEncoder().encode(token));
+    if (!schnorr.verify(hexToBytes(sig), hash, hexToBytes(delegator))) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  return { delegator, conditions };
+}
+
+/**
+ * Checks whether an event satisfies a NIP-26 conditions query string.
+ * Supported conditions: `kind=<n>`, `created_at<<n>`, `created_at><n>`.
+ *
+ * Conditions are joined by `&`. Multiple `kind=` entries are treated as a
+ * whitelist (the event kind must match ANY of them) — this matches how
+ * delegation tokens are generated in practice (e.g. `kind=1&kind=6&kind=7`).
+ * `created_at` bounds must all hold. An unknown condition is treated as
+ * unsatisfied so a malformed token is never shown as valid.
+ */
+function checkConditions(conditions: string, event: Nostr.Event): boolean {
+  if (!conditions) return true;
+
+  const allowedKinds: number[] = [];
+
+  for (const cond of conditions.split("&")) {
+    const kind = cond.match(/^kind=(\d+)$/);
+    if (kind) {
+      allowedKinds.push(Number(kind[1]));
+      continue;
+    }
+    const after = cond.match(/^created_at>(\d+)$/);
+    if (after) {
+      if (!(event.created_at > Number(after[1]))) return false;
+      continue;
+    }
+    const before = cond.match(/^created_at<(\d+)$/);
+    if (before) {
+      if (!(event.created_at < Number(before[1]))) return false;
+      continue;
+    }
+    return false;
+  }
+
+  if (allowedKinds.length > 0 && !allowedKinds.includes(event.kind)) {
+    return false;
+  }
+  return true;
+}

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -275,7 +275,7 @@
       "decrypt": "Decrypt and view contents"
     },
     "delegation": {
-      "delegatedBy": "on behalf"
+      "signedBy": "NIP-26 delegated · signed by {npub}"
     }
   },
   "mute": {

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -273,6 +273,9 @@
     "kind4": {
       "text": "( Old specification DM )",
       "decrypt": "Decrypt and view contents"
+    },
+    "delegation": {
+      "delegatedBy": "on behalf"
     }
   },
   "mute": {

--- a/src/lib/i18n/locales/ja.json
+++ b/src/lib/i18n/locales/ja.json
@@ -294,6 +294,9 @@
     "kind4": {
       "text": "(旧仕様のDM)",
       "decrypt": "復号して内容を見る"
+    },
+    "delegation": {
+      "delegatedBy": "の代理"
     }
   },
   "filter": {

--- a/src/lib/i18n/locales/ja.json
+++ b/src/lib/i18n/locales/ja.json
@@ -296,7 +296,7 @@
       "decrypt": "復号して内容を見る"
     },
     "delegation": {
-      "delegatedBy": "の代理"
+      "signedBy": "NIP-26 委任 · 署名鍵: {npub}"
     }
   },
   "filter": {


### PR DESCRIPTION
Verify the NIP-26 delegation tag (schnorr signature plus conditions) and, when valid, render the delegator as the note's author (icon, name, profile, status) instead of the delegatee signing key, which is typically a throwaway key with no profile. The signing key is kept for actions and moved into a small verified badge tooltip. Applies to kind 1/6/7 headers.