### PR TITLE
feat: cache kind:10002 in localStorage for offline fallback

### DIFF
--- a/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
+++ b/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
@@ -15,6 +15,9 @@
   import { defaultRelays } from "$lib/stores/relays";
   import { defaultRelays as defo, queryClient } from "$lib/stores/stores";
   import { app } from "$lib/stores/stores";
+  import { browser } from "$app/environment";
+  import { getKind10002Key } from "$lib/func/localStorageKeys";
+  import { formatToEventPacket } from "$lib/func/util";
   import {
     lumiSetting,
     relayConnectionState,
@@ -142,32 +145,91 @@
     return extractWriteRelays(relays);
   }
 
-  /** kind:10002をフェッチ（キャッシュ確認 → リクエスト） */
+  /** localStorageからkind:10002を読み込む */
+  function getLocalStored10002(): EventPacket | undefined {
+    if (!browser || !pubkey) return undefined;
+    try {
+      const stored = localStorage.getItem(getKind10002Key(pubkey));
+      if (!stored) return undefined;
+      const parsed = JSON.parse(stored);
+      if (!isEvent(parsed)) return undefined;
+      return formatToEventPacket(parsed);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** kind:10002をlocalStorageに保存する */
+  function saveLocal10002(event: Nostr.Event): void {
+    if (!browser || !pubkey) return;
+    try {
+      localStorage.setItem(getKind10002Key(pubkey), JSON.stringify(event));
+    } catch (e) {
+      console.warn("Failed to save kind:10002 to localStorage:", e);
+    }
+  }
+
+  /** Nostr.Event型ガード */
+  const isEvent = (v: unknown): v is Nostr.Event =>
+    !!v && typeof v === "object" && "created_at" in v;
+
+  /** kind:10002をフェッチ（キャッシュ確認 → ネットワーク → localStorage比較・保存） */
   async function fetchKind10002(
     onMidStreamData?: (packet: EventPacket) => void,
   ): Promise<EventPacket | undefined> {
-    // キャッシュチェック
+    // 1. TanStack Queryキャッシュチェック
     const cachedData: EventPacket | undefined | null =
       queryClient.getQueryData(queryKey);
     if (cachedData) return cachedData;
 
-    // フェッチ
+    // 2. localStorageからフォールバック候補を読み込み
+    const localFallback = getLocalStored10002();
+
+    // 3. ネットワークフェッチ
     $app.rxNostr.setDefaultRelays(defaultRelays);
-    const result = await usePromiseReq(
-      { filters, operator: pipe(uniq(), latest()) },
-      defaultRelays,
-      3000,
-      (packets: EventPacket[]) => {
-        if (packets.length > 0) {
-          queryClient.setQueryData(queryKey, packets[0]);
-          onMidStreamData?.(packets[0]);
-        }
-      },
-    );
-    if (result.length > 0) {
-      queryClient.setQueryData(queryKey, result[0]);
-      return result[0];
+    let networkResult: EventPacket | undefined;
+    try {
+      const result = await usePromiseReq(
+        { filters, operator: pipe(uniq(), latest()) },
+        defaultRelays,
+        3000,
+        (packets: EventPacket[]) => {
+          if (packets.length > 0) {
+            queryClient.setQueryData(queryKey, packets[0]);
+            onMidStreamData?.(packets[0]);
+          }
+        },
+      );
+      if (result.length > 0) {
+        networkResult = result[0];
+      }
+    } catch (e) {
+      console.warn("kind:10002 fetch failed:", e);
     }
+
+    // 4. ネットワーク結果がある場合: localStorageと比較し新しい方を使用
+    if (networkResult) {
+      const localEvent = localFallback?.event;
+      const networkEvent = networkResult.event;
+
+      if (!localEvent || networkEvent.created_at >= localEvent.created_at) {
+        // ネットワーク結果が新しい → localStorageに保存
+        saveLocal10002(networkEvent);
+        queryClient.setQueryData(queryKey, networkResult);
+        return networkResult;
+      } else {
+        // localStorageのの方が新しい → そちらを使用
+        queryClient.setQueryData(queryKey, localFallback);
+        return localFallback;
+      }
+    }
+
+    // 5. ネットワーク失敗時: localStorageをフォールバックとして使用
+    if (localFallback) {
+      queryClient.setQueryData(queryKey, localFallback);
+      return localFallback;
+    }
+
     return undefined;
   }
 

--- a/src/lib/func/localStorageKeys.ts
+++ b/src/lib/func/localStorageKeys.ts
@@ -20,3 +20,4 @@ export const STORAGE_KEYS = {
 };
 
 export const getKind3Key = (pubkey: string) => `kind3-${pubkey}`;
+export const getKind10002Key = (pubkey: string) => `kind10002-${pubkey}`;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -60,7 +60,7 @@
   } from "$lib/func/reactions";
   import { setRelaysByKind10002 } from "$lib/stores/useRelaySet";
   import { initThemeSettings } from "$lib/func/theme";
-  import { STORAGE_KEYS } from "$lib/func/localStorageKeys";
+  import { STORAGE_KEYS, getKind10002Key } from "$lib/func/localStorageKeys";
 
   // Workerインポート
   import workerUrl from "$lib/worker?worker&url";
@@ -75,6 +75,7 @@
   // スタイルインポート
   import "../app.css";
   import { getProfile } from "$lib/func/event";
+  import { formatToEventPacket } from "$lib/func/util";
   import { nip19 } from "nostr-tools";
   import LoginUserContacts from "$lib/components/renderSnippets/nostr/LoginUserContacts.svelte";
   import { saveLocalStorage } from "$lib/func/storage";
@@ -148,8 +149,28 @@
     if (data && data.length > 0) {
       const relays = setRelaysByKind10002(data[0].event);
       setRelays(relays);
-    } else {
-      // キャッシュになければネットワークから取得
+      return;
+    }
+
+    // localStorageからフォールバック候補を読み込み
+    let localFallback: EventPacket | undefined;
+    try {
+      const stored = localStorage.getItem(getKind10002Key(currentPubkey));
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          "created_at" in parsed
+        ) {
+          localFallback = formatToEventPacket(parsed);
+        }
+      }
+    } catch {}
+
+    // ネットワークから取得
+    let networkResult: EventPacket | undefined;
+    try {
       const relays = await usePromiseReq(
         {
           filters: [{ authors: [currentPubkey], kinds: [10002], limit: 1 }],
@@ -158,11 +179,39 @@
         undefined,
         undefined,
       );
-
-      if (relays) {
-        const processedRelays = setRelaysByKind10002(relays[0].event);
-        setRelays(processedRelays);
+      if (relays && relays.length > 0) {
+        networkResult = relays[0];
       }
+    } catch (e) {
+      console.warn("kind:10002 fetch failed in setUserRelay:", e);
+    }
+
+    if (networkResult) {
+      const localEvent = localFallback?.event;
+      const networkEvent = networkResult.event;
+
+      if (!localEvent || networkEvent.created_at >= localEvent.created_at) {
+        // ネットワーク結果が新しい → localStorageに保存
+        try {
+          localStorage.setItem(
+            getKind10002Key(currentPubkey),
+            JSON.stringify(networkEvent),
+          );
+        } catch {}
+        const relays = setRelaysByKind10002(networkEvent);
+        setRelays(relays);
+      } else {
+        // localStorageのの方が新しい → そちらを使用
+        const relays = setRelaysByKind10002(localEvent);
+        setRelays(relays);
+      }
+      return;
+    }
+
+    // ネットワーク失敗時: localStorageをフォールバックとして使用
+    if (localFallback) {
+      const relays = setRelaysByKind10002(localFallback.event);
+      setRelays(relays);
     }
   }
 


### PR DESCRIPTION
- Add getKind10002Key helper to localStorageKeys.ts
- Modify fetchKind10002() in SetDefaultRelays.svelte to read/write localStorage
- Modify setUserRelay() in +layout.svelte with same localStorage fallback logic
- Compare created_at to always use the newer event between network and cache