### PR TITLE
feat: cache kind:10002 in localStorage for offline fallback

### DIFF
--- a/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
+++ b/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
@@ -27,6 +27,7 @@
   import type { AcceptableDefaultRelaysConfig } from "rx-nostr";
   import { get } from "svelte/store";
   import { normalizeURL } from "nostr-tools/utils";
+  import { validateEvent } from "nostr-tools/core";
 
   interface Props {
     paramRelays: string[] | undefined;
@@ -152,7 +153,7 @@
       const stored = localStorage.getItem(getKind10002Key(pubkey));
       if (!stored) return undefined;
       const parsed = JSON.parse(stored);
-      if (!isEvent(parsed)) return undefined;
+      if (!validateEvent(parsed)) return undefined;
       return formatToEventPacket(parsed);
     } catch {
       return undefined;
@@ -168,10 +169,6 @@
       console.warn("Failed to save kind:10002 to localStorage:", e);
     }
   }
-
-  /** Nostr.Event型ガード */
-  const isEvent = (v: unknown): v is Nostr.Event =>
-    !!v && typeof v === "object" && "created_at" in v;
 
   /** kind:10002をフェッチ（キャッシュ確認 → ネットワーク → localStorage比較・保存） */
   async function fetchKind10002(

--- a/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
+++ b/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
@@ -175,30 +175,16 @@
     }
   }
 
-  /** kind:10002をフェッチ（キャッシュ確認 → ネットワーク → localStorage比較・保存） */
+  /** kind:10002をフェッチ（常時ネットワーク取得、cache/localStorageと比較して最新を使用） */
   async function fetchKind10002(
     onMidStreamData?: (packet: EventPacket) => void,
   ): Promise<EventPacket | undefined> {
-    // 1. TanStack Queryキャッシュチェック
+    // 1. フォールバック候補を事前読み込み
     const cachedData: EventPacket | undefined | null =
       queryClient.getQueryData(queryKey);
-    if (cachedData) {
-      // キャッシュがある場合もlocalStorageと比較
-      const localFallback = getLocalStored10002();
-      if (
-        localFallback &&
-        localFallback.event.created_at > cachedData.event.created_at
-      ) {
-        queryClient.setQueryData(queryKey, localFallback);
-        return localFallback;
-      }
-      return cachedData;
-    }
-
-    // 2. localStorageからフォールバック候補を読み込み
     const localFallback = getLocalStored10002();
 
-    // 3. ネットワークフェッチ
+    // 2. 常時ネットワークフェッチ
     $app.rxNostr.setDefaultRelays(defaultRelays);
     let networkResult: EventPacket | undefined;
     try {
@@ -220,30 +206,29 @@
       console.warn("kind:10002 fetch failed:", e);
     }
 
-    // 4. ネットワーク結果がある場合: localStorageと比較し新しい方を使用
-    if (networkResult) {
-      const localEvent = localFallback?.event;
-      const networkEvent = networkResult.event;
+    // 3. 全候補から最新を選択
+    const candidates: EventPacket[] = [
+      localFallback,
+      cachedData,
+      networkResult,
+    ].filter((c): c is EventPacket => c != null);
 
-      if (!localEvent || networkEvent.created_at >= localEvent.created_at) {
-        // ネットワーク結果が新しい → localStorageに保存
-        saveLocal10002(networkEvent);
-        queryClient.setQueryData(queryKey, networkResult);
-        return networkResult;
-      } else {
-        // localStorageのの方が新しい → そちらを使用
-        queryClient.setQueryData(queryKey, localFallback);
-        return localFallback;
-      }
+    if (candidates.length === 0) return undefined;
+
+    const newest = candidates.reduce((a, b) =>
+      a.event.created_at >= b.event.created_at ? a : b,
+    );
+
+    // 4. localStorageに保存（kind/pubkey一致時のみ）
+    if (
+      newest.event.kind === 10002 &&
+      newest.event.pubkey === pubkey
+    ) {
+      saveLocal10002(newest.event);
     }
 
-    // 5. ネットワーク失敗時: localStorageをフォールバックとして使用
-    if (localFallback) {
-      queryClient.setQueryData(queryKey, localFallback);
-      return localFallback;
-    }
-
-    return undefined;
+    queryClient.setQueryData(queryKey, newest);
+    return newest;
   }
 
   // --- paramRelaysあり: paramRelaysをread用、10002のwriteをマージ ---

--- a/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
+++ b/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
@@ -153,7 +153,12 @@
       const stored = localStorage.getItem(getKind10002Key(pubkey));
       if (!stored) return undefined;
       const parsed = JSON.parse(stored);
-      if (!validateEvent(parsed)) return undefined;
+      if (
+        !validateEvent(parsed) ||
+        parsed.kind !== 10002 ||
+        parsed.pubkey !== pubkey
+      )
+        return undefined;
       return formatToEventPacket(parsed);
     } catch {
       return undefined;
@@ -177,7 +182,18 @@
     // 1. TanStack Queryキャッシュチェック
     const cachedData: EventPacket | undefined | null =
       queryClient.getQueryData(queryKey);
-    if (cachedData) return cachedData;
+    if (cachedData) {
+      // キャッシュがある場合もlocalStorageと比較
+      const localFallback = getLocalStored10002();
+      if (
+        localFallback &&
+        localFallback.event.created_at > cachedData.event.created_at
+      ) {
+        queryClient.setQueryData(queryKey, localFallback);
+        return localFallback;
+      }
+      return cachedData;
+    }
 
     // 2. localStorageからフォールバック候補を読み込み
     const localFallback = getLocalStored10002();

--- a/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
+++ b/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
@@ -15,6 +15,9 @@
   import { defaultRelays } from "$lib/stores/relays";
   import { defaultRelays as defo, queryClient } from "$lib/stores/stores";
   import { app } from "$lib/stores/stores";
+  import { browser } from "$app/environment";
+  import { getKind10002Key } from "$lib/func/localStorageKeys";
+  import { formatToEventPacket } from "$lib/func/util";
   import {
     lumiSetting,
     relayConnectionState,
@@ -142,32 +145,91 @@
     return extractWriteRelays(relays);
   }
 
-  /** kind:10002をフェッチ（キャッシュ確認 → リクエスト） */
+  /** localStorageからkind:10002を読み込む */
+  function getLocalStored10002(): EventPacket | undefined {
+    if (!browser || !pubkey) return undefined;
+    try {
+      const stored = localStorage.getItem(getKind10002Key(pubkey));
+      if (!stored) return undefined;
+      const parsed = JSON.parse(stored);
+      if (!isEvent(parsed)) return undefined;
+      return formatToEventPacket(parsed);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** kind:10002をlocalStorageに保存する */
+  function saveLocal10002(event: Nostr.Event): void {
+    if (!browser || !pubkey) return;
+    try {
+      localStorage.setItem(getKind10002Key(pubkey), JSON.stringify(event));
+    } catch (e) {
+      console.warn("Failed to save kind:10002 to localStorage:", e);
+    }
+  }
+
+  /** Nostr.Event型ガード */
+  const isEvent = (v: unknown): v is Nostr.Event =>
+    !!v && typeof v === "object" && "created_at" in v;
+
+  /** kind:10002をフェッチ（キャッシュ確認 → ネットワーク → localStorage比較・保存） */
   async function fetchKind10002(
     onMidStreamData?: (packet: EventPacket) => void,
   ): Promise<EventPacket | undefined> {
-    // キャッシュチェック
+    // 1. TanStack Queryキャッシュチェック
     const cachedData: EventPacket | undefined | null =
       queryClient.getQueryData(queryKey);
     if (cachedData) return cachedData;
 
-    // フェッチ
+    // 2. localStorageからフォールバック候補を読み込み
+    const localFallback = getLocalStored10002();
+
+    // 3. ネットワークフェッチ
     $app.rxNostr.setDefaultRelays(defaultRelays);
-    const result = await usePromiseReq(
-      { filters, operator: pipe(uniq(), latest()) },
-      defaultRelays,
-      3000,
-      (packets: EventPacket[]) => {
-        if (packets.length > 0) {
-          queryClient.setQueryData(queryKey, packets[0]);
-          onMidStreamData?.(packets[0]);
-        }
-      },
-    );
-    if (result.length > 0) {
-      queryClient.setQueryData(queryKey, result[0]);
-      return result[0];
+    let networkResult: EventPacket | undefined;
+    try {
+      const result = await usePromiseReq(
+        { filters, operator: pipe(uniq(), latest()) },
+        defaultRelays,
+        3000,
+        (packets: EventPacket[]) => {
+          if (packets.length > 0) {
+            queryClient.setQueryData(queryKey, packets[0]);
+            onMidStreamData?.(packets[0]);
+          }
+        },
+      );
+      if (result.length > 0) {
+        networkResult = result[0];
+      }
+    } catch (e) {
+      console.warn("kind:10002 fetch failed:", e);
     }
+
+    // 4. ネットワーク結果がある場合: localStorageと比較し新しい方を使用
+    if (networkResult) {
+      const localEvent = localFallback?.event;
+      const networkEvent = networkResult.event;
+
+      if (!localEvent || networkEvent.created_at >= localEvent.created_at) {
+        // ネットワーク結果が新しい → localStorageに保存
+        saveLocal10002(networkEvent);
+        queryClient.setQueryData(queryKey, networkResult);
+        return networkResult;
+      } else {
+        // localStorageのの方が新しい → そちらを使用
+        queryClient.setQueryData(queryKey, localFallback);
+        return localFallback;
+      }
+    }
+
+    // 5. ネットワーク失敗時: localStorageをフォールバックとして使用
+    if (localFallback) {
+      queryClient.setQueryData(queryKey, localFallback);
+      return localFallback;
+    }
+
     return undefined;
   }
 

--- a/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
+++ b/src/lib/components/renderSnippets/nostr/relay/SetDefaultRelays.svelte
@@ -180,8 +180,12 @@
     onMidStreamData?: (packet: EventPacket) => void,
   ): Promise<EventPacket | undefined> {
     // 1. フォールバック候補を事前読み込み
-    const cachedData: EventPacket | undefined | null =
+    const rawCache: EventPacket | undefined | null =
       queryClient.getQueryData(queryKey);
+    const cachedData =
+      rawCache?.event?.kind === 10002 && rawCache.event.pubkey === pubkey
+        ? rawCache
+        : undefined;
     const localFallback = getLocalStored10002();
 
     // 2. 常時ネットワークフェッチ

--- a/src/lib/func/localStorageKeys.ts
+++ b/src/lib/func/localStorageKeys.ts
@@ -20,3 +20,4 @@ export const STORAGE_KEYS = {
 };
 
 export const getKind3Key = (pubkey: string) => `kind3-${pubkey}`;
+export const getKind10002Key = (pubkey: string) => `kind10002-${pubkey}`;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -150,6 +150,13 @@
     if (data && data.length > 0) {
       const relays = setRelaysByKind10002(data[0].event);
       setRelays(relays);
+      // キャッシュヒット時もlocalStorageを更新
+      try {
+        localStorage.setItem(
+          getKind10002Key(currentPubkey),
+          JSON.stringify(data[0].event),
+        );
+      } catch {}
       return;
     }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -148,13 +148,31 @@
     ]);
 
     if (data && data.length > 0) {
-      const relays = setRelaysByKind10002(data[0].event);
+      const cacheEvent = data[0].event;
+      // localStorageと比較し、新しい方を使用
+      try {
+        const stored = localStorage.getItem(getKind10002Key(currentPubkey));
+        if (stored) {
+          const localEvent = JSON.parse(stored);
+          if (
+            validateEvent(localEvent) &&
+            localEvent.kind === 10002 &&
+            localEvent.pubkey === currentPubkey &&
+            localEvent.created_at > cacheEvent.created_at
+          ) {
+            const relays = setRelaysByKind10002(localEvent);
+            setRelays(relays);
+            return;
+          }
+        }
+      } catch {}
+      // キャッシュが新しい or localStorageなし → キャッシュを保存
+      const relays = setRelaysByKind10002(cacheEvent);
       setRelays(relays);
-      // キャッシュヒット時もlocalStorageを更新
       try {
         localStorage.setItem(
           getKind10002Key(currentPubkey),
-          JSON.stringify(data[0].event),
+          JSON.stringify(cacheEvent),
         );
       } catch {}
       return;
@@ -166,7 +184,11 @@
       const stored = localStorage.getItem(getKind10002Key(currentPubkey));
       if (stored) {
         const parsed = JSON.parse(stored);
-        if (validateEvent(parsed)) {
+        if (
+          validateEvent(parsed) &&
+          parsed.kind === 10002 &&
+          parsed.pubkey === currentPubkey
+        ) {
           localFallback = formatToEventPacket(parsed);
         }
       }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -142,11 +142,10 @@
     const currentPubkey = lumiSetting.value.pubkey;
 
     // 1. フォールバック候補を事前読み込み
-    const cachedData: EventPacket[] | undefined = queryClient.getQueryData([
+    const cacheEvent: EventPacket | undefined = queryClient.getQueryData([
       "defaultRelay",
       currentPubkey,
     ]);
-    const cacheEvent = cachedData?.[0];
 
     let localFallback: EventPacket | undefined;
     try {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -141,44 +141,13 @@
   async function setUserRelay() {
     const currentPubkey = lumiSetting.value.pubkey;
 
-    // キャッシュから取得を試行
-    const data: EventPacket[] | undefined = queryClient.getQueryData([
+    // 1. フォールバック候補を事前読み込み
+    const cachedData: EventPacket[] | undefined = queryClient.getQueryData([
       "defaultRelay",
       currentPubkey,
     ]);
+    const cacheEvent = cachedData?.[0];
 
-    if (data && data.length > 0) {
-      const cacheEvent = data[0].event;
-      // localStorageと比較し、新しい方を使用
-      try {
-        const stored = localStorage.getItem(getKind10002Key(currentPubkey));
-        if (stored) {
-          const localEvent = JSON.parse(stored);
-          if (
-            validateEvent(localEvent) &&
-            localEvent.kind === 10002 &&
-            localEvent.pubkey === currentPubkey &&
-            localEvent.created_at > cacheEvent.created_at
-          ) {
-            const relays = setRelaysByKind10002(localEvent);
-            setRelays(relays);
-            return;
-          }
-        }
-      } catch {}
-      // キャッシュが新しい or localStorageなし → キャッシュを保存
-      const relays = setRelaysByKind10002(cacheEvent);
-      setRelays(relays);
-      try {
-        localStorage.setItem(
-          getKind10002Key(currentPubkey),
-          JSON.stringify(cacheEvent),
-        );
-      } catch {}
-      return;
-    }
-
-    // localStorageからフォールバック候補を読み込み
     let localFallback: EventPacket | undefined;
     try {
       const stored = localStorage.getItem(getKind10002Key(currentPubkey));
@@ -194,7 +163,7 @@
       }
     } catch {}
 
-    // ネットワークから取得
+    // 2. 常時ネットワークから取得
     let networkResult: EventPacket | undefined;
     try {
       const relays = await usePromiseReq(
@@ -212,33 +181,35 @@
       console.warn("kind:10002 fetch failed in setUserRelay:", e);
     }
 
-    if (networkResult) {
-      const localEvent = localFallback?.event;
-      const networkEvent = networkResult.event;
+    // 3. 全候補から最新を選択
+    const candidates: EventPacket[] = [
+      localFallback,
+      cacheEvent,
+      networkResult,
+    ].filter((c): c is EventPacket => c != null);
 
-      if (!localEvent || networkEvent.created_at >= localEvent.created_at) {
-        // ネットワーク結果が新しい → localStorageに保存
-        try {
-          localStorage.setItem(
-            getKind10002Key(currentPubkey),
-            JSON.stringify(networkEvent),
-          );
-        } catch {}
-        const relays = setRelaysByKind10002(networkEvent);
-        setRelays(relays);
-      } else {
-        // localStorageのの方が新しい → そちらを使用
-        const relays = setRelaysByKind10002(localEvent);
-        setRelays(relays);
-      }
-      return;
+    if (candidates.length === 0) return;
+
+    const newest = candidates.reduce((a, b) =>
+      a.event.created_at >= b.event.created_at ? a : b,
+    );
+
+    // 4. localStorageに保存（kind/pubkey一致時のみ）
+    if (
+      newest.event.kind === 10002 &&
+      newest.event.pubkey === currentPubkey
+    ) {
+      try {
+        localStorage.setItem(
+          getKind10002Key(currentPubkey),
+          JSON.stringify(newest.event),
+        );
+      } catch {}
     }
 
-    // ネットワーク失敗時: localStorageをフォールバックとして使用
-    if (localFallback) {
-      const relays = setRelaysByKind10002(localFallback.event);
-      setRelays(relays);
-    }
+    queryClient.setQueryData(["defaultRelay", currentPubkey], newest);
+    const relays = setRelaysByKind10002(newest.event);
+    setRelays(relays);
   }
 
   // ページ可視性変更時の処理（リレー再接続）

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -77,6 +77,7 @@
   import { getProfile } from "$lib/func/event";
   import { formatToEventPacket } from "$lib/func/util";
   import { nip19 } from "nostr-tools";
+  import { validateEvent } from "nostr-tools/core";
   import LoginUserContacts from "$lib/components/renderSnippets/nostr/LoginUserContacts.svelte";
   import { saveLocalStorage } from "$lib/func/storage";
 
@@ -158,11 +159,7 @@
       const stored = localStorage.getItem(getKind10002Key(currentPubkey));
       if (stored) {
         const parsed = JSON.parse(stored);
-        if (
-          parsed &&
-          typeof parsed === "object" &&
-          "created_at" in parsed
-        ) {
+        if (validateEvent(parsed)) {
           localFallback = formatToEventPacket(parsed);
         }
       }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -142,10 +142,15 @@
     const currentPubkey = lumiSetting.value.pubkey;
 
     // 1. フォールバック候補を事前読み込み
-    const cacheEvent: EventPacket | undefined = queryClient.getQueryData([
+    const rawCache: EventPacket | undefined = queryClient.getQueryData([
       "defaultRelay",
       currentPubkey,
     ]);
+    const cacheEvent =
+      rawCache?.event?.kind === 10002 &&
+      rawCache.event.pubkey === currentPubkey
+        ? rawCache
+        : undefined;
 
     let localFallback: EventPacket | undefined;
     try {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -60,7 +60,7 @@
   } from "$lib/func/reactions";
   import { setRelaysByKind10002 } from "$lib/stores/useRelaySet";
   import { initThemeSettings } from "$lib/func/theme";
-  import { STORAGE_KEYS } from "$lib/func/localStorageKeys";
+  import { STORAGE_KEYS, getKind10002Key } from "$lib/func/localStorageKeys";
 
   // Workerインポート
   import workerUrl from "$lib/worker?worker&url";
@@ -75,6 +75,7 @@
   // スタイルインポート
   import "../app.css";
   import { getProfile } from "$lib/func/event";
+  import { formatToEventPacket } from "$lib/func/util";
   import { nip19 } from "nostr-tools";
   import LoginUserContacts from "$lib/components/renderSnippets/nostr/LoginUserContacts.svelte";
   import { saveLocalStorage } from "$lib/func/storage";
@@ -148,8 +149,28 @@
     if (data && data.length > 0) {
       const relays = setRelaysByKind10002(data[0].event);
       setRelays(relays);
-    } else {
-      // キャッシュになければネットワークから取得
+      return;
+    }
+
+    // localStorageからフォールバック候補を読み込み
+    let localFallback: EventPacket | undefined;
+    try {
+      const stored = localStorage.getItem(getKind10002Key(currentPubkey));
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          "created_at" in parsed
+        ) {
+          localFallback = formatToEventPacket(parsed);
+        }
+      }
+    } catch {}
+
+    // ネットワークから取得
+    let networkResult: EventPacket | undefined;
+    try {
       const relays = await usePromiseReq(
         {
           filters: [{ authors: [currentPubkey], kinds: [10002], limit: 1 }],
@@ -158,11 +179,39 @@
         undefined,
         undefined,
       );
-
-      if (relays) {
-        const processedRelays = setRelaysByKind10002(relays[0].event);
-        setRelays(processedRelays);
+      if (relays && relays.length > 0) {
+        networkResult = relays[0];
       }
+    } catch (e) {
+      console.warn("kind:10002 fetch failed in setUserRelay:", e);
+    }
+
+    if (networkResult) {
+      const localEvent = localFallback?.event;
+      const networkEvent = networkResult.event;
+
+      if (!localEvent || networkEvent.created_at >= localEvent.created_at) {
+        // ネットワーク結果が新しい → localStorageに保存
+        try {
+          localStorage.setItem(
+            getKind10002Key(currentPubkey),
+            JSON.stringify(networkEvent),
+          );
+        } catch {}
+        const relays = setRelaysByKind10002(networkEvent);
+        setRelays(relays);
+      } else {
+        // localStorageのの方が新しい → そちらを使用
+        const relays = setRelaysByKind10002(localEvent);
+        setRelays(relays);
+      }
+      return;
+    }
+
+    // ネットワーク失敗時: localStorageをフォールバックとして使用
+    if (localFallback) {
+      const relays = setRelaysByKind10002(localFallback.event);
+      setRelays(relays);
     }
   }
 


### PR DESCRIPTION
## 概要
ログインユーザーの kind:10002 (NIP-65 relay list) を localStorage に保存し、ネットワーク取得失敗時にフォールバックとして使用できるようにします。

## 変更内容

### localStorage キャッシュ
- `localStorageKeys.ts`: `getKind10002Key()` ヘルパー関数を追加
- キー形式: `kind10002-{pubkey}`

### SetDefaultRelays.svelte
- `fetchKind10002()` を改修:
  1. TanStack Query キャッシュ確認
  2. localStorage 確認
  3. ネットワークフェッチ（常時実行）
  4. ネットワーク結果と localStorage を `created_at` で比較し、新しい方を使用・保存
  5. ネットワーク失敗時は localStorage をフォールバックとして使用

### +layout.svelte
- `setUserRelay()` に同様の localStorage フォールバックロジックを追加
- キャッシュヒット時にも localStorage を同期（レビュー指摘対応）

### その他
- カスタム `isEvent` タイプガードを `nostr-tools/core` の `validateEvent` に置き換え